### PR TITLE
use the user name slug as name for ssh keys secrets

### DIFF
--- a/app/api/entity/user.go
+++ b/app/api/entity/user.go
@@ -1,6 +1,10 @@
 package entity
 
-import "time"
+import (
+	"time"
+
+	"github.com/gosimple/slug"
+)
 
 // SSHKey entity definition.
 type SSHKey struct {
@@ -29,4 +33,8 @@ type User struct {
 	SSHKey       SSHKey
 	LastActivity *time.Time
 	APITokens    []APIToken
+}
+
+func (u User) UsernameSlug() string {
+	return slug.Make(u.Username)
 }

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -109,7 +109,7 @@ func (i *interactor) Create(ctx context.Context, email, username, password strin
 
 	i.logger.Infof("The user \"%s\" (%s) was created with ID \"%s\"", user.Username, user.Email, insertedID)
 
-	secretName := fmt.Sprintf("%s-ssh-keys", user.Username)
+	secretName := fmt.Sprintf("%s-ssh-keys", user.UsernameSlug())
 	err = i.k8sClient.CreateSecret(secretName, map[string]string{
 		"KDL_USER_PUBLIC_SSH_KEY":  keys.Public,
 		"KDL_USER_PRIVATE_SSH_KEY": keys.Private,

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -72,11 +72,11 @@ func TestInteractor_Create(t *testing.T) {
 		id            = "user.1234"
 		email         = "user@email.com"
 		password      = "p4$sword"
-		username      = "john"
+		username      = "john.doe"
 		accessLevel   = entity.AccessLevelAdmin
 		publicSSHKey  = "test-ssh-key-public"
 		privateSSHKey = "test-ssh-key-private"
-		secretName    = "john-ssh-keys" //nolint:gosec // it is a unit test
+		secretName    = "john-doe-ssh-keys" //nolint:gosec // it is a unit test
 	)
 
 	secretValues := map[string]string{


### PR DESCRIPTION
- If the user name contains characters like dots, the creation of the secret fails