### PR TITLE
use the username slug to stop the user tools

### DIFF
--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -16,7 +16,8 @@ import (
 
 // DeleteUserToolsCR removes the Custom Resource from Kubernetes.
 func (k *k8sClient) DeleteUserToolsCR(ctx context.Context, username string) error {
-	resName := k.getUserToolsResName(username)
+	slugUsername := k.getSlugUsername(username)
+	resName := k.getUserToolsResName(slugUsername)
 
 	var zero int64 = 0
 


### PR DESCRIPTION
The resource name for the user-tools contains the username slug but the API is using the username.
It fails if the user name contains dots like: john.doe