### PR TITLE
fix(app): typo in app/api/infrastructure/k8s/usertools.go

### DIFF
--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -195,7 +195,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, slu
 						"pullPolicy": k.cfg.RepoCloner.Image.PullPolicy,
 					},
 				},
-				"giteaOAuth2Setup": map[string]interface{}{
+				"giteaOauth2Setup": map[string]interface{}{
 					"image": map[string]string{
 						"repository": k.cfg.UserToolsGiteaOAuth2Setup.Image.Repository,
 						"tag":        k.cfg.UserToolsGiteaOAuth2Setup.Image.Tag,


### PR DESCRIPTION
This PR fixes a bug that produces kubernetes "usertools" resources are being generated without giteaOauth2Setup configuration.

To test this on a running KDL local dev environment:
```
$ ./kdlctl.sh build
$ ./kdlctl.sh deploy
```
Enjoy!