### PR TITLE
fix(vscode): Change installation files out of coder home

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -64,7 +64,6 @@ LABEL maintainer="Intelygenz - Konstellation Team"
 
 COPY instantclient-basic-linux.x64-18.5.0.0.0dbru.zip \
       instantclient-sdk-linux.x64-18.5.0.0.0dbru.zip /tmp/
-COPY --chown=coder:coder default_user_settings.json /config/default_user_settings.json
 
 COPY --from=odbc-builder /opt/odbc/ /usr/local/
 COPY --from=golang-builder --chown=coder:coder $GOPATH/ $GOPATH/
@@ -129,6 +128,7 @@ USER coder
 WORKDIR /home/coder
 
 # Install VSCode extensions
+COPY --chown=coder:coder default_user_settings.json /vscode/config/default_user_settings.json
 COPY --chown=coder:coder entrypoint.sh /entrypoint.sh
 RUN code-server \
       --install-extension christian-kohler.path-intellisense \
@@ -146,6 +146,6 @@ RUN code-server \
       --install-extension wayou.vscode-todo-highlight \
       --install-extension yzhang.markdown-all-in-one \
       --install-extension zxh404.vscode-proto3 \
-      --extensions-dir ~/.vscode/extensions
+      --extensions-dir /vscode/extensions
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/vscode/entrypoint.sh
+++ b/vscode/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DEFAULT_SETTINGS_FILE="/config/default_user_settings.json"
+DEFAULT_SETTINGS_FILE="/vscode/config/default_user_settings.json"
 USER_SETTINGS_DIR="$HOME/.local/share/code-server/User"
 SETTINGS_FILE="${USER_SETTINGS_DIR}/settings.json"
 TMP_FILE=$(mktemp)
@@ -17,10 +17,12 @@ fi
 jq -s '.[1] * .[0]' ${DEFAULT_SETTINGS_FILE} ${SETTINGS_FILE} > ${TMP_FILE} \
       && mv ${TMP_FILE} ${SETTINGS_FILE}
 
+
+
 dumb-init code-server \
   --auth none \
   --host 0.0.0.0 \
   --port 8080 \
   --disable-telemetry \
-  --extensions-dir ~/.vscode/extensions \
+  --extensions-dir /vscode/extensions \
   /home/coder


### PR DESCRIPTION
We need to change the VS Code extensions and entrypoint.sh files location out of coder home, given that this folder is going to be replaced with a persistent volume when the container is created (see helm statetfulset template)