### PR TITLE
fix(jupyter-gpu): tensorflow==2.0.0b1 python library cannot be installed anymore

### DIFF
--- a/jupyter-gpu/Dockerfile
+++ b/jupyter-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 as odbc-builder
+FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu18.04 as odbc-builder
 
 LABEL maintainer="ODBC Builder"
 
@@ -26,7 +26,7 @@ RUN apt-get update && \
     # It is needed to tar the files to preserve symlinks
     tar cf /opt/odbc.tar -C /opt odbc/
 
-FROM nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
+FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu18.04
 
 # Maintainer of the Dockerfile
 LABEL maintainer="Intelygenz - Konstellation Team"

--- a/jupyter-gpu/requirements.txt
+++ b/jupyter-gpu/requirements.txt
@@ -47,7 +47,7 @@ pyodbc==4.0.30
 pytest==6.2.4
 pytest-asyncio==0.15.1
 python-igraph==0.9.4
-pytorch-lightning==1.3.5
+pytorch-lightning==1.3.8
 pytorch-nlp==0.5.0
 scikit-image==0.18.1
 scikit-learn==0.24.2
@@ -58,7 +58,7 @@ spacy==3.0.6
 SQLAlchemy==1.4.17
 statsmodels==0.12.2
 tables==3.6.1
-tensorflow==2.0.0b1 # needed to have tensorboard features
+tensorflow==2.7.0-rc1 # needed to have tensorboard features
 torch==1.8.1
 torch-geometric==1.7.0
 torchsummary==1.5.1


### PR DESCRIPTION
The solution is to upgrade image base to `nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu18.04` and the following libraries:
* tensorflow: 2.0.0b1 -> 2.7.0-rc1
* pytorch-lightning: 1.3.5 -> 1.3.8