### PR TITLE
Fix typo 

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -40,5 +40,5 @@ jobs:
     needs: helm-release
     uses: konstellation-io/github-workflows/.github/workflows/chart-release.yaml@v1.3.0
     with:
-      chart_dir: helm
+      chart_path: helm
       chart_url: http://kdl.konstellation.io


### PR DESCRIPTION
Fix typo on helm-release. `chart_url` instead `chart_dir`.