### PR TITLE
feat(helm): Allow use custom TLS secret

### DIFF
--- a/helm/kdl-server/templates/_helpers.tpl
+++ b/helm/kdl-server/templates/_helpers.tpl
@@ -18,3 +18,14 @@ Create MongoDB URI.
     {{ default "knowledge-galaxy" .Values.knowledgeGalaxy.serviceaccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create tls secret name
+*/}}
+{{- define "tlsSecretName" -}}
+{{- if .Values.tls.certManager.enabled -}}
+  {{- printf "%s-tls-secret" $.Values.domain -}}
+{{- else -}}
+  {{- .Values.tls.secretName -}}
+{{- end -}}
+{{- end -}}

--- a/helm/kdl-server/templates/app/ingress.yaml
+++ b/helm/kdl-server/templates/app/ingress.yaml
@@ -21,7 +21,7 @@ spec:
   tls:
     - hosts:
         - kdlapp.{{ .Values.domain }}
-      secretName: {{ .Values.domain }}-tls-secret
+      secretName: {{ include "tlsSecretName" . }}
   {{- end }}
   rules:
     - host: kdlapp.{{ .Values.domain }}

--- a/helm/kdl-server/templates/drone/configmap.yaml
+++ b/helm/kdl-server/templates/drone/configmap.yaml
@@ -26,6 +26,6 @@ data:
   DRONE_SECRET_PLUGIN_TOKEN: {{ .Values.drone.pluginSecret }}
   DRONE_TOKEN: {{ .Values.drone.adminToken }}
   DRONE_INTERNAL_URL: "http://drone"
-  {{- if .Values.kdl.local }}
+  {{- if and (and .Values.tls.enabled (not .Values.tls.certManager.enabled)) .Values.tls.caSecret }}
   DRONE_RUNNER_ENVIRON: GIT_SSL_NO_VERIFY:true
   {{- end }}

--- a/helm/kdl-server/templates/drone/ingress.yaml
+++ b/helm/kdl-server/templates/drone/ingress.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - hosts:
         - drone.{{ .Values.domain }}
-      secretName: {{ .Values.domain }}-tls-secret
+      secretName: {{ include "tlsSecretName" . }}
   {{- end }}
   rules:
     - host: drone.{{ .Values.domain }}

--- a/helm/kdl-server/templates/drone/runner-deployment.yaml
+++ b/helm/kdl-server/templates/drone/runner-deployment.yaml
@@ -30,13 +30,13 @@ spec:
         envFrom:
           - configMapRef:
               name: drone-config
-      {{- if .Values.kdl.local }}
+      {{- if and (and .Values.tls.enabled (not .Values.tls.certManager.enabled)) .Values.tls.caSecret }}
         volumeMounts:
-        - mountPath: /etc/ssl/certs/mkcert-ca.pem
-          name: mkcert-ca
-          subPath: mkcert-ca.crt
+        - mountPath: /etc/ssl/certs/ca-cert.pem
+          name: ca-cert
+          subPath: {{ .Values.tls.caSecret.certFilename }}
       volumes:
-      - name: mkcert-ca
+      - name: ca-cert
         secret:
-          secretName: mkcert-ca
+          secretName: {{ .Values.tls.caSecret.name }}
       {{- end }}

--- a/helm/kdl-server/templates/gitea/ingress.yaml
+++ b/helm/kdl-server/templates/gitea/ingress.yaml
@@ -20,7 +20,7 @@ spec:
   tls:
     - hosts:
         - gitea.{{ .Values.domain }}
-      secretName: {{ .Values.domain }}-tls-secret
+      secretName: {{ include "tlsSecretName" . }}
   {{- end }}
   rules:
     - host: gitea.{{ .Values.domain }}

--- a/helm/kdl-server/templates/gitea/statefulset.yaml
+++ b/helm/kdl-server/templates/gitea/statefulset.yaml
@@ -47,10 +47,10 @@ spec:
             - name: gitea-init
               mountPath: /usr/local/bin/create-admin.sh
               subPath: create-admin.sh
-            {{- if .Values.kdl.local }}
-            - mountPath: /etc/ssl/certs/mkcert-ca.pem
-              name: mkcert-ca
-              subPath: mkcert-ca.crt
+            {{- if and (and .Values.tls.enabled (not .Values.tls.certManager.enabled)) .Values.tls.caSecret }}
+            - mountPath: /etc/ssl/certs/ca-cert.pem
+              name: ca-cert
+              subPath: {{ .Values.tls.caSecret.certFilename }}
             {{- end }}
           livenessProbe:
             httpGet:
@@ -63,10 +63,10 @@ spec:
           configMap:
             name: gitea-init
             defaultMode: 0777
-        {{- if .Values.kdl.local }}
-        - name: mkcert-ca
+        {{- if and (and .Values.tls.enabled (not .Values.tls.certManager.enabled)) .Values.tls.caSecret }}
+        - name: ca-cert
           secret:
-            secretName: mkcert-ca
+            secretName: {{ .Values.tls.caSecret.name }}
         {{- end }}
   volumeClaimTemplates:
     - metadata:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -90,9 +90,6 @@ ingress:
   type: nginx
   nginxConnectionTimeout: "3600"
 
-kdl:
-  local: false
-
 knowledgeGalaxy:
   enabled: false
   image:
@@ -200,6 +197,13 @@ sharedVolume:
   storageClassName: standard
   size: 10Gi
 
+## TLS configuration for Ingresses, Gitea and Drone.
+## If tls.certManager.enabled=true, Cert Manager
+## certificates will be used.
+##
+## Alternatively a tls secret can be used. In that
+## case the secret must be manually created in the namespace
+##
 tls:
   enabled: true
   certManager:
@@ -207,6 +211,21 @@ tls:
     acme:
       server: https://acme-v02.api.letsencrypt.org/directory
       email: user@email.com
+
+  ## Custom TLS secret
+  ## Must be a valid wildcard certificate for the domain
+  ## declared in .Values.domain
+  ## Certificate name example:
+  ##   *.example.com
+  #
+  # secretName: kdl-server-tls
+
+  ## A secret containing the the CA cert is needed
+  ## in order to use a self-signed certificate
+  ## 
+  # caSecret:
+  #   name: kdl-ca-cert
+  #   certFilename: ca.crt
 
 userToolsOperator:
   image:

--- a/scripts/kdlctl/cmd_deploy.sh
+++ b/scripts/kdlctl/cmd_deploy.sh
@@ -117,7 +117,6 @@ deploy_helm_chart() {
     --set gitea.storage.storageClassName=$STORAGE_CLASS_NAME \
     --set giteaOauth2Setup.image.pullPolicy="Always" \
     --set giteaOauth2Setup.image.repository="$IMAGE_REGISTRY/konstellation/gitea-oauth2-setup" \
-    --set kdl.local="true" \
     --set kdlServer.image.pullPolicy="Always" \
     --set kdlServer.image.repository="$IMAGE_REGISTRY/konstellation/kdl-server" \
     --set knowledgeGalaxy.image.pullPolicy="Always" \
@@ -132,6 +131,10 @@ deploy_helm_chart() {
     --set projectOperator.mlflow.image.pullPolicy="Always" \
     --set projectOperator.mlflow.image.repository="$IMAGE_REGISTRY/konstellation/mlflow" \
     --set projectOperator.mlflow.volume.storageClassName=$STORAGE_CLASS_NAME \
+    --set tls.enabled=${ENABLE_TLS} \
+    --set tls.secretName=${DOMAIN}-tls-secret \
+    --set tls.caSecret.name=mkcert-ca \
+    --set tls.caSecret.certFilename=mkcert-ca.crt \
     --set userToolsOperator.image.pullPolicy="Always" \
     --set userToolsOperator.image.repository="$IMAGE_REGISTRY/konstellation/user-tools-operator" \
     --set userToolsOperator.jupyter.image.pullPolicy="Always" \

--- a/scripts/kdlctl/cmd_login.sh
+++ b/scripts/kdlctl/cmd_login.sh
@@ -12,7 +12,13 @@ show_login_help() {
 }
 
 local_login() {
-  LINK=https://kdlapp.kdl.$HOST_IP.nip.io
+  if [ "$ENABLE_TLS" = "true" ];
+  then
+    export SCHEMA="https"
+  else
+    export SCHEMA="http"
+  fi
+  LINK=$SCHEMA://kdlapp.kdl.$HOST_IP.nip.io
   echo "Login link  : ${LINK}"
   echo "👤 User     : ${GITEA_ADMIN_USER}"
   echo "🔑 Password : ${GITEA_ADMIN_PASSWORD}"


### PR DESCRIPTION
This feature will allow:
* A custom previous manually deployed custom secret can be specified when tls is enabled if integrated cert manager resources are disable
* A custom CA certificate can be added in case the custom tls secret contains a self-signed certificate.This is needed for Gitea and Drone Runner containers in order they could accept the certificates included in the above secret.