### PR TITLE
fix(helm): KdlApp ingress timeout values

### DIFF
--- a/helm/kdl-server/templates/app/ingress.yaml
+++ b/helm/kdl-server/templates/app/ingress.yaml
@@ -12,9 +12,9 @@ metadata:
     {{ if eq .Values.ingress.type "nginx" }}
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.ingress.nginxConnectionTimeout }}"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.ingress.nginxConnectionTimeout }}"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.ingress.nginxConnectionTimeout }}"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.kdlServer.ingress.proxyReadTimeout }}"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.kdlServer.ingress.proxySendTimeout }}"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.kdlServer.ingress.proxyConnectTimeout }}"
     {{ end }}
 spec:
   {{ if .Values.tls.enabled -}}

--- a/helm/kdl-server/templates/app/ingress.yaml
+++ b/helm/kdl-server/templates/app/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     {{ if eq .Values.ingress.type "nginx" }}
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.kdlServer.ingress.proxyBodySize }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.kdlServer.ingress.proxyReadTimeout }}"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.kdlServer.ingress.proxySendTimeout }}"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.kdlServer.ingress.proxyConnectTimeout }}"

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -129,6 +129,10 @@ kdlServer:
     proxySendTimeout: "3600"
     proxyConnectTimeout: "3600"
 
+    ## Large values are needed to serve big files from Filebrowser
+    ##
+    proxyBodySize: "1000000m"
+
 minio:
   resources:
     requests:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -89,7 +89,6 @@ giteaOauth2Setup:
 
 ingress:
   type: nginx
-  nginxConnectionTimeout: "3600"
 
 knowledgeGalaxy:
   enabled: false
@@ -125,6 +124,10 @@ kdlServer:
     repository: konstellation/kdl-server
     tag: v0.18.0
     pullPolicy: IfNotPresent
+  ingress:
+    proxyReadTimeout: "3600"
+    proxySendTimeout: "3600"
+    proxyConnectTimeout: "3600"
 
 minio:
   resources:
@@ -178,7 +181,6 @@ postgres:
     storageClassName: standard
 
 projectOperator:
-
   ## Main container specs
   ##
   manager:
@@ -251,7 +253,7 @@ tls:
 
   ## A secret containing the the CA cert is needed
   ## in order to use a self-signed certificate
-  ## 
+  ##
   # caSecret:
   #   name: kdl-ca-cert
   #   certFilename: ca.crt


### PR DESCRIPTION
KdlApp ingress timeout values are now under `.Values.kdlApp.ingress` dictionary.