### PR TITLE
fix(helm): kdlServer.image.version.tag in values.yaml

### DIFF
--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -177,7 +177,7 @@ knowledgeGalaxy:
 kdlServer:
   image:
     repository: konstellation/kdl-server
-    tag: v0.22.0
+    tag: 0.22.0
     pullPolicy: IfNotPresent
   ingress:
     proxyReadTimeout: "3600"


### PR DESCRIPTION
Changes `kdlServer.image.version.tag: v0.22.0` to `kdlServer.image.version.tag: 0.22.0` because `konstellation/kdl-server:v0.22.0` Docker image does not exists.