### PR TITLE
fix: update versions in versions files

### DIFF
--- a/.github/workflows/backup-component-build.yml
+++ b/.github/workflows/backup-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: backup
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: backup
       component_helm_tag: backup.image.tag

--- a/.github/workflows/cleaner-component-build.yml
+++ b/.github/workflows/cleaner-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: cleaner
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: cleaner
       component_helm_tag: cleaner.image.tag

--- a/.github/workflows/drone-authorizer-component-build.yml
+++ b/.github/workflows/drone-authorizer-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: drone-authorizer
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: drone-authorizer
       component_helm_tag: droneAuthorizer.image.tag

--- a/.github/workflows/gitea-oauth2-setup-component-build.yml
+++ b/.github/workflows/gitea-oauth2-setup-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: gitea-oauth2-setup
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: gitea-oauth2-setup
       component_helm_tag: giteaOauth2Setup.image.tag

--- a/.github/workflows/helm-component.yml
+++ b/.github/workflows/helm-component.yml
@@ -22,4 +22,4 @@ concurrency: build_component
 
 jobs:
   helm-lint:
-    uses: konstellation-io/github-workflows/.github/workflows/helm-lint.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/helm-lint.yaml@v1.7.0

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -23,7 +23,7 @@ concurrency: helm_release
 jobs:
   helm-release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: konstellation-io/github-workflows/.github/workflows/helm-release.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/helm-release.yaml@v1.7.0
     with:
       chart_file: helm/kdl-server/Chart.yaml
       chart_path: helm

--- a/.github/workflows/jupyter-gpu-component-build.yml
+++ b/.github/workflows/jupyter-gpu-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: jupyter-gpu
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: jupyter-gpu
       component_helm_tag: userToolsOperator.jupyter.image.tag

--- a/.github/workflows/kdl-server-component-build.yml
+++ b/.github/workflows/kdl-server-component-build.yml
@@ -18,7 +18,7 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: app
 
@@ -84,7 +84,7 @@ jobs:
 
   build:
     needs: [ lint-dockerfile, quality-checks ]
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: kdl-app
       component_helm_tag: kdlServer.image.tag

--- a/.github/workflows/mlflow-component-build.yml
+++ b/.github/workflows/mlflow-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: mlflow
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: mlflow
       component_helm_tag: projectOperator.mlflow.image.tag

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   new-release:
-    uses: konstellation-io/github-workflows/.github/workflows/new-release.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/new-release.yaml@v1.7.0
     with:
       chart_file: helm/kdl-server/Chart.yaml
       chart_path: helm

--- a/.github/workflows/project-operator-component-build.yml
+++ b/.github/workflows/project-operator-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: project-operator
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: project-operator
       component_helm_tag: projectOperator.image.tag

--- a/.github/workflows/repo-cloner-component-build.yml
+++ b/.github/workflows/repo-cloner-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: repo-cloner
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: repo-cloner
       component_helm_tag: userToolsOperator.repoCloner.image.tag

--- a/.github/workflows/user-tools-operator-component-build.yml
+++ b/.github/workflows/user-tools-operator-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: user-tools-operator
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: user-tools-operator
       component_helm_tag: userToolsOperator.image.tag

--- a/.github/workflows/vscode-component-build.yml
+++ b/.github/workflows/vscode-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
     with:
       component_path: vscode
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.6.1
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
     with:
       component: vscode
       component_helm_tag: userToolsOperator.vscode.image.tag


### PR DESCRIPTION
When update the versions files (helm `values.yaml)`) they where updating with the tag (eg. `v.2.1.2`) but we are generating the docker images tagged with the version (eg. `2.1.2`). The new versions of the workflows solves this issue.