### PR TITLE
ci: force major release in kdl app

### DIFF
--- a/app/api/README.md
+++ b/app/api/README.md
@@ -14,7 +14,6 @@ In order to develop in a local environment there are several things to consider:
 6. run `go run http/main.go` (or launch it from your preferred IDE)
 7. You can now access the graphQL playground at `http://localhost:3000/api/playground`
 
-
 ## Testing
 
 To create new tests install [GoMock](https://github.com/golang/mock). Mocks used on tests are generated with
@@ -25,6 +24,7 @@ To create new tests install [GoMock](https://github.com/golang/mock). Mocks used
 ```
 
 To generate the mocks execute:
+
 ```sh
 $ go generate ./...
 ```
@@ -40,10 +40,11 @@ go test ./...
 `golangci-lint` is a fast Go linters runner. It runs linters in parallel, uses caching, supports yaml config, has
 integrations with all major IDE and has dozens of linters included.
 
-As you can see in the `.golangci.yml` config file of this repo, we enable more linters than the default and
-have more strict settings.
+As you can see in the `.golangci.yml` config file of this repo, we enable more linters than the default and have more
+strict settings.
 
 To run `golangci-lint` execute:
+
 ```
 golangci-lint run
 ```


### PR DESCRIPTION
We have manually created a new tag `kdl-app-v1.0.0` that forces the new kdl-app release to be `v1.1.0`.