### PR TITLE
fix(ui): add e2e tests

### DIFF
--- a/.github/workflows/backup-component-build.yml
+++ b/.github/workflows/backup-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: backup
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: backup
       component_helm_tag: backup.image.tag

--- a/.github/workflows/cleaner-component-build.yml
+++ b/.github/workflows/cleaner-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: cleaner
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: cleaner
       component_helm_tag: cleaner.image.tag

--- a/.github/workflows/drone-authorizer-component-build.yml
+++ b/.github/workflows/drone-authorizer-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: drone-authorizer
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: drone-authorizer
       component_helm_tag: droneAuthorizer.image.tag

--- a/.github/workflows/gitea-oauth2-setup-component-build.yml
+++ b/.github/workflows/gitea-oauth2-setup-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: gitea-oauth2-setup
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: gitea-oauth2-setup
       component_helm_tag: giteaOauth2Setup.image.tag

--- a/.github/workflows/helm-component.yml
+++ b/.github/workflows/helm-component.yml
@@ -22,4 +22,4 @@ concurrency: build_component
 
 jobs:
   helm-lint:
-    uses: konstellation-io/github-workflows/.github/workflows/helm-lint.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/helm-lint.yaml@v1.7.1

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -23,7 +23,7 @@ concurrency: helm_release
 jobs:
   helm-release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: konstellation-io/github-workflows/.github/workflows/helm-release.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/helm-release.yaml@v1.7.1
     with:
       chart_file: helm/kdl-server/Chart.yaml
       chart_path: helm

--- a/.github/workflows/jupyter-gpu-component-build.yml
+++ b/.github/workflows/jupyter-gpu-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: jupyter-gpu
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: jupyter-gpu
       component_helm_tag: userToolsOperator.jupyter.image.tag

--- a/.github/workflows/kdl-server-component-build.yml
+++ b/.github/workflows/kdl-server-component-build.yml
@@ -18,7 +18,7 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: app
 
@@ -84,7 +84,7 @@ jobs:
 
   build:
     needs: [ lint-dockerfile, quality-checks ]
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: kdl-app
       component_helm_tag: kdlServer.image.tag

--- a/.github/workflows/mlflow-component-build.yml
+++ b/.github/workflows/mlflow-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: mlflow
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: mlflow
       component_helm_tag: projectOperator.mlflow.image.tag

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   new-release:
-    uses: konstellation-io/github-workflows/.github/workflows/new-release.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/new-release.yaml@v1.7.1
     with:
       chart_file: helm/kdl-server/Chart.yaml
       chart_path: helm

--- a/.github/workflows/project-operator-component-build.yml
+++ b/.github/workflows/project-operator-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: project-operator
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: project-operator
       component_helm_tag: projectOperator.image.tag

--- a/.github/workflows/repo-cloner-component-build.yml
+++ b/.github/workflows/repo-cloner-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: repo-cloner
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: repo-cloner
       component_helm_tag: userToolsOperator.repoCloner.image.tag

--- a/.github/workflows/user-tools-operator-component-build.yml
+++ b/.github/workflows/user-tools-operator-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: user-tools-operator
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: user-tools-operator
       component_helm_tag: userToolsOperator.image.tag

--- a/.github/workflows/vscode-component-build.yml
+++ b/.github/workflows/vscode-component-build.yml
@@ -18,13 +18,13 @@ concurrency: build_component
 
 jobs:
   lint-dockerfile:
-    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/lint-dockerfile.yaml@v1.7.1
     with:
       component_path: vscode
 
   build:
     needs: lint-dockerfile
-    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.0
+    uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.1
     with:
       component: vscode
       component_helm_tag: userToolsOperator.vscode.image.tag

--- a/app/ui/.eslintrc.yaml
+++ b/app/ui/.eslintrc.yaml
@@ -54,3 +54,4 @@ rules:
   semi:
     - error
     - always
+  "@typescript-eslint/no-namespace": "off"

--- a/app/ui/.gitignore
+++ b/app/ui/.gitignore
@@ -27,3 +27,4 @@ screenshots
 videos
 
 cypress/fixtures/example.json
+cypress/downloads/*

--- a/app/ui/cypress/integration/kubeconfig.spec.ts
+++ b/app/ui/cypress/integration/kubeconfig.spec.ts
@@ -1,0 +1,62 @@
+import GetMeQuery from '../../src/Mocks/GetMeQuery';
+import GetRuntimesQuery from '../../src/Mocks/GetRuntimesQuery';
+import { join } from 'path';
+
+describe('Kubeconfig Pages Behavior', () => {
+  beforeEach(() => {
+    cy.kstInterceptor('GetMe', { data: GetMeQuery });
+    cy.kstInterceptor('GetRuntimes', { data: GetRuntimesQuery });
+    cy.kstInterceptor('GetKubeconfig', { data: { kubeconfig: 'test kubeconfig' } });
+
+    cy.visit('http://localhost:3001/#/user/kubeconfig');
+  });
+
+  it('should show kubeconfig page', () => {
+    // Assert.
+    cy.url().should('contain', '/kubeconfig');
+  });
+
+  it('should load kubeconfig', () => {
+    // GIVEN there is a kubeconfig
+    const kubeconfig = 'test kubeconfig';
+    cy.kstInterceptor('GetKubeconfig', { data: { kubeconfig } });
+
+    // THEN the kubeconfig page should render it
+    cy.getByTestId('kubeconfig').should('contain', kubeconfig);
+  });
+
+  it('should copy kubeconfig to clipboard', () => {
+    // GIVEN there is a kubeconfig
+    const kubeconfig = 'test kubeconfig';
+    cy.kstInterceptor('GetKubeconfig', { data: { kubeconfig } });
+
+    // WHEN the copy button is clicked
+    cy.getByTestId('kubeconfigButtons').children().first().click();
+
+    // THEN the clipboard contains the kubeconfig
+    cy.window().then((win: Window) => {
+      win.navigator.clipboard
+        .readText()
+        .then((text) => {
+          assert.equal(text, kubeconfig);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    });
+    cy.contains('Copied to clipboard').should('exist');
+  });
+
+  it('should download kubeconfig', () => {
+    // GIVEN there is a kubeconfig
+    const kubeconfig = 'test kubeconfig';
+    cy.kstInterceptor('GetKubeconfig', { data: { kubeconfig } });
+
+    // WHEN the download button is clicked
+    cy.getByTestId('kubeconfigButtons').children().last().click();
+
+    // THEN the kubeconfig should be downloaded
+    const downloadFolder = Cypress.config('downloadsFolder');
+    cy.readFile(join(downloadFolder, 'kubeconfig')).should('exist');
+  });
+});

--- a/app/ui/cypress/integration/kubeconfig.spec.ts
+++ b/app/ui/cypress/integration/kubeconfig.spec.ts
@@ -16,6 +16,14 @@ describe('Kubeconfig Pages Behavior', () => {
     cy.url().should('contain', '/kubeconfig');
   });
 
+  it('should redirect to projects if kubeconfig isnt enabled', () => {
+    cy.kstInterceptor('GetMe', { data: { me: { ...GetMeQuery.me, isKubeconfigEnabled: false } } });
+    cy.visit('http://localhost:3001/#/user/kubeconfig');
+
+    // Assert.
+    cy.url().should('contain', '/projects');
+  });
+
   it('should load kubeconfig', () => {
     // GIVEN there is a kubeconfig
     const kubeconfig = 'test kubeconfig';

--- a/app/ui/cypress/integration/runtimes.spec.ts
+++ b/app/ui/cypress/integration/runtimes.spec.ts
@@ -1,0 +1,122 @@
+import GetProjectsQuery from '../../src/Mocks/GetProjectsQuery';
+import GetMeQuery from '../../src/Mocks/GetMeQuery';
+import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
+import GetRuntimesQuery from '../../src/Mocks/GetRuntimesQuery';
+
+describe('Project Navigation Bar Behavior', () => {
+  beforeEach(() => {
+    // There is a list of projects
+    cy.kstInterceptor('GetProjects', { data: GetProjectsQuery });
+    // and a user logged
+    cy.kstInterceptor('GetMe', { data: GetMeQuery });
+    // and a list of available runtimes
+    cy.kstInterceptor('GetRuntimes', { data: GetRuntimesQuery });
+
+    cy.visit('http://localhost:3001');
+    cy.getByTestId('project').first().parent().click();
+  });
+
+  it('should open a warning modal when the user try to stop the tools', () => {
+    // GIVEN there is a runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+    // WHEN the stop runtime button is clicked
+    cy.getByTestId('stopTools').click();
+
+    // THEN the stop tools confirmation modal is opened
+    cy.getByTestId('stopToolsModal').should('exist');
+  });
+
+  it('should open runtimes panels is there is no runtime selected when start tools', () => {
+    // GIVEN there is no runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: null });
+
+    // WHEN the start runtime button on the left sidebar is clicked
+    cy.getByTestId('startTools').click();
+
+    // THEN the runtime list panel is opened
+    cy.getByTestId('runtimesListPanel').should('exist');
+  });
+
+  it('should start runtime in runtime info panel', () => {
+    // GIVEN there is no runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: null });
+
+    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+    cy.getByTestId('openRuntimeSettings').click();
+    cy.getByTestId('runtimesList').children().first().click();
+    cy.getByTestId('panelStartRuntime').click();
+
+    // THEN the runtime is running
+    cy.getByTestId('statusTag').contains('Running');
+  });
+
+  it('should stop tools with runtime info stop button', () => {
+    // GIVEN there is a runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+    // WHEN runtime is stopped from runtime info panel
+    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
+    cy.getByTestId('openRuntimeSettings').click();
+    cy.getByTestId('runtimesList').children().first().click();
+    cy.getByTestId('panelStopRuntime').click();
+    cy.contains('Stop Tools').click();
+
+    // THEN the runtime isn't running
+    cy.getByTestId('statusTag').should('not.exist');
+  });
+
+  it('should redirect to overview page if runtime is stopped and a tool is open', () => {
+    // GIVEN there is no runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: null });
+
+    // WHEN a tool is opened
+    cy.contains('Vscode').click({ force: true });
+
+    // THEN the navigation is redirected to overview page
+    cy.url().should('contain', 'overview');
+  });
+
+  it('should allow open user tools if runtime is started', () => {
+    // GIVEN there is a runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+    // WHEN a tool is opened
+    cy.contains('Vscode').click();
+
+    // THEN the tools is open
+    cy.url().should('contain', 'vscode');
+  });
+
+  it('should replace runtime if there is a runtime running but another is started', () => {
+    // GIVEN there is no runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+    cy.getByTestId('openRuntimeSettings').click();
+    cy.getByTestId('runtimesList').children().last().click();
+    cy.getByTestId('panelStartRuntime').click();
+    cy.contains('Replace Tools').click();
+
+    // THEN the runtime is running
+    cy.getByTestId('statusTag').contains('Running');
+  });
+
+  it('should redirect to overview page if try to open tools during replacement of runtimes', () => {
+    // GIVEN there is a runtime started
+    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+    // and the runtime is being replaced with certain delay
+    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } }, { delay: 1000 });
+    cy.getByTestId('openRuntimeSettings').click();
+    cy.getByTestId('runtimesList').children().last().click();
+    cy.getByTestId('panelStartRuntime').click();
+    cy.contains('Replace Tools').click();
+
+    // WHEN try to open a user tool while request is pending
+    cy.contains('Vscode').click({ force: true });
+
+    // THEN should redirect to overview page
+    cy.url().should('contain', '/overview');
+  });
+});

--- a/app/ui/cypress/integration/runtimes.spec.ts
+++ b/app/ui/cypress/integration/runtimes.spec.ts
@@ -3,7 +3,7 @@ import GetMeQuery from '../../src/Mocks/GetMeQuery';
 import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
 import GetRuntimesQuery from '../../src/Mocks/GetRuntimesQuery';
 
-describe('Project Navigation Bar Behavior', () => {
+describe('Runtimes Behaviour', () => {
   beforeEach(() => {
     // There is a list of projects
     cy.kstInterceptor('GetProjects', { data: GetProjectsQuery });
@@ -16,107 +16,115 @@ describe('Project Navigation Bar Behavior', () => {
     cy.getByTestId('project').first().parent().click();
   });
 
-  it('should open a warning modal when the user try to stop the tools', () => {
-    // GIVEN there is a runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+  describe('Left Sidebar Buttons Behaviour', () => {
+    it('should open runtimes panels is there is no runtime selected when start tools', () => {
+      // GIVEN there is no runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: null });
 
-    // WHEN the stop runtime button is clicked
-    cy.getByTestId('stopTools').click();
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.getByTestId('startTools').click();
 
-    // THEN the stop tools confirmation modal is opened
-    cy.getByTestId('stopToolsModal').should('exist');
+      // THEN the runtime list panel is opened
+      cy.getByTestId('runtimesListPanel').should('exist');
+    });
+
+    it('should open a warning modal when the user try to stop the tools', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+      // WHEN the stop runtime button is clicked
+      cy.getByTestId('stopTools').click();
+
+      // THEN the stop tools confirmation modal is opened
+      cy.getByTestId('stopToolsModal').should('exist');
+    });
+
+    // TODO: Test de arrancar ultimo runtime
   });
 
-  it('should open runtimes panels is there is no runtime selected when start tools', () => {
-    // GIVEN there is no runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: null });
+  describe('Runtime Info Panel Behaviour', () => {
+    it('should start runtime in runtime info panel', () => {
+      // GIVEN there is no runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: null });
 
-    // WHEN the start runtime button on the left sidebar is clicked
-    cy.getByTestId('startTools').click();
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+      cy.getByTestId('panelStartRuntime').click();
 
-    // THEN the runtime list panel is opened
-    cy.getByTestId('runtimesListPanel').should('exist');
+      // THEN the runtime is running
+      cy.getByTestId('statusTag').contains('Running');
+    });
+
+    it('should stop tools with runtime info stop button', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+      // WHEN runtime is stopped from runtime info panel
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+      cy.getByTestId('panelStopRuntime').click();
+      cy.contains('Stop Tools').click();
+
+      // THEN the runtime isn't running
+      cy.getByTestId('statusTag').should('not.exist');
+    });
+
+    it('should replace runtime if there is a runtime running but another is started', () => {
+      // GIVEN there is no runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().last().click();
+      cy.getByTestId('panelStartRuntime').click();
+      cy.contains('Replace Tools').click();
+
+      // THEN the runtime is running
+      cy.getByTestId('statusTag').contains('Running');
+    });
   });
 
-  it('should start runtime in runtime info panel', () => {
-    // GIVEN there is no runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: null });
+  describe('User Tools Navigation Behaviour', () => {
+    it('should redirect to overview page if runtime is stopped and a tool is open', () => {
+      // GIVEN there is no runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: null });
 
-    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
-    cy.getByTestId('openRuntimeSettings').click();
-    cy.getByTestId('runtimesList').children().first().click();
-    cy.getByTestId('panelStartRuntime').click();
+      // WHEN a tool is opened
+      cy.contains('Vscode').click({ force: true });
 
-    // THEN the runtime is running
-    cy.getByTestId('statusTag').contains('Running');
-  });
+      // THEN the navigation is redirected to overview page
+      cy.url().should('contain', 'overview');
+    });
 
-  it('should stop tools with runtime info stop button', () => {
-    // GIVEN there is a runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+    it('should allow open user tools if runtime is started', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
 
-    // WHEN runtime is stopped from runtime info panel
-    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
-    cy.getByTestId('openRuntimeSettings').click();
-    cy.getByTestId('runtimesList').children().first().click();
-    cy.getByTestId('panelStopRuntime').click();
-    cy.contains('Stop Tools').click();
+      // WHEN a tool is opened
+      cy.contains('Vscode').click();
 
-    // THEN the runtime isn't running
-    cy.getByTestId('statusTag').should('not.exist');
-  });
+      // THEN the tools is open
+      cy.url().should('contain', 'vscode');
+    });
 
-  it('should redirect to overview page if runtime is stopped and a tool is open', () => {
-    // GIVEN there is no runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: null });
+    it('should redirect to overview page if try to open tools during replacement of runtimes', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
 
-    // WHEN a tool is opened
-    cy.contains('Vscode').click({ force: true });
+      // and the runtime is being replaced with certain delay
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } }, { delay: 1000 });
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().last().click();
+      cy.getByTestId('panelStartRuntime').click();
+      cy.contains('Replace Tools').click();
 
-    // THEN the navigation is redirected to overview page
-    cy.url().should('contain', 'overview');
-  });
+      // WHEN try to open a user tool while request is pending
+      cy.contains('Vscode').click({ force: true });
 
-  it('should allow open user tools if runtime is started', () => {
-    // GIVEN there is a runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
-
-    // WHEN a tool is opened
-    cy.contains('Vscode').click();
-
-    // THEN the tools is open
-    cy.url().should('contain', 'vscode');
-  });
-
-  it('should replace runtime if there is a runtime running but another is started', () => {
-    // GIVEN there is no runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
-
-    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
-    cy.getByTestId('openRuntimeSettings').click();
-    cy.getByTestId('runtimesList').children().last().click();
-    cy.getByTestId('panelStartRuntime').click();
-    cy.contains('Replace Tools').click();
-
-    // THEN the runtime is running
-    cy.getByTestId('statusTag').contains('Running');
-  });
-
-  it('should redirect to overview page if try to open tools during replacement of runtimes', () => {
-    // GIVEN there is a runtime started
-    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
-
-    // and the runtime is being replaced with certain delay
-    cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } }, { delay: 1000 });
-    cy.getByTestId('openRuntimeSettings').click();
-    cy.getByTestId('runtimesList').children().last().click();
-    cy.getByTestId('panelStartRuntime').click();
-    cy.contains('Replace Tools').click();
-
-    // WHEN try to open a user tool while request is pending
-    cy.contains('Vscode').click({ force: true });
-
-    // THEN should redirect to overview page
-    cy.url().should('contain', '/overview');
+      // THEN should redirect to overview page
+      cy.url().should('contain', '/overview');
+    });
   });
 });

--- a/app/ui/cypress/support/commands.ts
+++ b/app/ui/cypress/support/commands.ts
@@ -1,0 +1,23 @@
+import Chainable = Cypress.Chainable;
+
+Cypress.Commands.add('kstInterceptor', (operation, responseObject, options): Chainable => {
+  return cy.intercept('/api/query', (req) => {
+    const { operationName } = req.body;
+    if (operationName === operation)
+      req.reply({ body: responseObject, ...(options?.delay ? { delay: options.delay } : {}) });
+  });
+});
+
+Cypress.Commands.add('getByTestId', (dataTestId) => cy.get(`[data-testid="${dataTestId}"]`));
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+Cypress.Commands.add('findByTestId', { prevSubject: true }, (subject, dataTestId) =>
+  subject.find(`[data-testid="${dataTestId}"]`),
+);
+
+Cypress.Commands.add('openSettings', () => {
+  cy.visit('http://localhost:3001');
+  cy.getByTestId('project').first().parent().click();
+  cy.getByTestId('toggleSettings').click();
+});

--- a/app/ui/cypress/support/index.ts
+++ b/app/ui/cypress/support/index.ts
@@ -1,9 +1,10 @@
 import Chainable = Cypress.Chainable;
 
-Cypress.Commands.add('kstInterceptor', (operation, responseObject): Chainable => {
+Cypress.Commands.add('kstInterceptor', (operation, responseObject, options): Chainable => {
   return cy.intercept('/api/query', (req) => {
     const { operationName } = req.body;
-    if (operationName === operation) req.reply(responseObject);
+    if (operationName === operation)
+      req.reply({ body: responseObject, ...(options?.delay ? { delay: options.delay } : {}) });
   });
 });
 
@@ -31,7 +32,7 @@ declare namespace Cypress {
      * Custom command to intercept GraphQl queries from the KDL.
      * @example cy.kstInterceptor('GetMe', {name: 'Jon Doe'})
      */
-    kstInterceptor(operation: string, responseObject: Object): Chainable;
+    kstInterceptor(operation: string, responseObject: Object, options?: { delay?: number }): Chainable;
 
     /**
      * Custom command to get element by data-testid

--- a/app/ui/cypress/support/index.ts
+++ b/app/ui/cypress/support/index.ts
@@ -1,55 +1,31 @@
-import Chainable = Cypress.Chainable;
+import './commands';
 
-Cypress.Commands.add('kstInterceptor', (operation, responseObject, options): Chainable => {
-  return cy.intercept('/api/query', (req) => {
-    const { operationName } = req.body;
-    if (operationName === operation)
-      req.reply({ body: responseObject, ...(options?.delay ? { delay: options.delay } : {}) });
-  });
-});
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Custom command to intercept GraphQl queries from the KDL.
+       * @example cy.kstInterceptor('GetMe', {name: 'Jon Doe'})
+       */
+      kstInterceptor(operation: string, responseObject: Object, options?: { delay?: number }): Chainable;
 
-Cypress.Commands.add('getByTestId', (dataTestId) => cy.get(`[data-testid="${dataTestId}"]`));
+      /**
+       * Custom command to get element by data-testid
+       * @example cy.getByTestId('my-data-testid')
+       */
+      getByTestId(dataTestId: string): Chainable;
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-Cypress.Commands.add('findByTestId', { prevSubject: true }, (subject, dataTestId) =>
-  subject.find(`[data-testid="${dataTestId}"]`),
-);
+      /**
+       * Custom command to find an element by data-testid
+       * @example cy.findByTestId('my-data-testid')
+       */
+      findByTestId(dataTestId: string): Chainable;
 
-Cypress.Commands.add('openSettings', () => {
-  cy.visit('http://localhost:3001');
-  cy.getByTestId('project').first().parent().click();
-  cy.getByTestId('toggleSettings').click();
-});
-
-// load type definitions that come with Cypress module
-/// <reference types="cypress" />
-
-// eslint-disable-next-line @typescript-eslint/no-namespace
-declare namespace Cypress {
-  interface Chainable {
-    /**
-     * Custom command to intercept GraphQl queries from the KDL.
-     * @example cy.kstInterceptor('GetMe', {name: 'Jon Doe'})
-     */
-    kstInterceptor(operation: string, responseObject: Object, options?: { delay?: number }): Chainable;
-
-    /**
-     * Custom command to get element by data-testid
-     * @example cy.getByTestId('my-data-testid')
-     */
-    getByTestId(dataTestId: string): Chainable;
-
-    /**
-     * Custom command to find an element by data-testid
-     * @example cy.findByTestId('my-data-testid')
-     */
-    findByTestId(dataTestId: string): Chainable;
-
-    /**
-     * Custom command to open the settings
-     * @example cy.openSettings()
-     */
-    openSettings(): void;
+      /**
+       * Custom command to open the settings
+       * @example cy.openSettings()
+       */
+      openSettings(): void;
+    }
   }
 }

--- a/app/ui/cypress/tsconfig.json
+++ b/app/ui/cypress/tsconfig.json
@@ -6,6 +6,7 @@
   ],
   "compilerOptions": {
     "noEmit": false,
-    "isolatedModules": false
+    "isolatedModules": false,
+    "types": ["cypress"]
   }
 }

--- a/app/ui/mock-server/src/index.js
+++ b/app/ui/mock-server/src/index.js
@@ -15,12 +15,12 @@ app.use(
 // If you want to simulate a timeout you can uncomment these lines.
 // This function simply generate a random timeout and then it will return the response from the graphQL server.
 // Probably there is a better solution than this, but for dev environment it seems works fine.
-// app.use(async (req, __, next) => {
-//   const randomWait = casual.integer(2000, 5000);
-//   await new Promise((resolve) => setTimeout(resolve, randomWait));
-//
-//   next();
-// });
+app.use(async (req, __, next) => {
+  const randomWait = casual.integer(2000, 5000);
+  await new Promise((resolve) => setTimeout(resolve, randomWait));
+
+  next();
+});
 
 // # This endpoint is used to test unauthorized response
 // app.post('/graphql', (req, res) => {

--- a/app/ui/src/App.tsx
+++ b/app/ui/src/App.tsx
@@ -39,8 +39,13 @@ function Routes() {
         <Redirect exact from={ROUTE.HOME} to={ROUTE.PROJECTS} />
 
         {canAccessUsers && <Route exact path={ROUTE.USERS} component={Users} />}
+        {data.me.isKubeconfigEnabled ? (
+          <Route exact path={ROUTE.USER_KUBECONFIG} component={UserKubeconfig} />
+        ) : (
+          <Redirect exact from={ROUTE.USER_KUBECONFIG} to={ROUTE.PROJECTS} />
+        )}
+
         <Route exact path={ROUTE.USER_SSH_KEY} component={UserSshKey} />
-        <Route exact path={ROUTE.USER_KUBECONFIG} component={UserKubeconfig} />
 
         <Route exact path={ROUTE.NEW_PROJECT} component={NewProject} />
         <Route exact path={ROUTE.PROJECT_CREATION} component={ProjectCreation} />

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb.tsx
@@ -25,6 +25,7 @@ function RuntimesCrumb() {
       crumbText={runtimeLastRan.name}
       isSelect={true}
       LeftIconComponent={<RuntimeIcon className="icon-regular" status={runtimeStatus} />}
+      dataTestId="runtimesCrumb"
     >
       {(props: BottomComponentProps) => <RuntimeSelector runtimes={data.runtimes} {...props} />}
     </Crumb>

--- a/app/ui/src/Mocks/GetRunningRuntimeQuery.ts
+++ b/app/ui/src/Mocks/GetRunningRuntimeQuery.ts
@@ -1,0 +1,5 @@
+import { runtime } from './entities/runtime';
+
+export default {
+  runningRuntime: runtime,
+};

--- a/app/ui/src/Mocks/GetRuntimesQuery.ts
+++ b/app/ui/src/Mocks/GetRuntimesQuery.ts
@@ -1,0 +1,5 @@
+import { runtime, runtime2 } from './entities/runtime';
+
+export default {
+  runtimes: [runtime, runtime2],
+};

--- a/app/ui/src/Mocks/entities/runtime.ts
+++ b/app/ui/src/Mocks/entities/runtime.ts
@@ -1,0 +1,23 @@
+import { GetRunningRuntime_runningRuntime } from '../../Graphql/queries/types/GetRunningRuntime';
+
+export const runtime: GetRunningRuntime_runningRuntime = {
+  __typename: 'Runtime',
+  id: 'test',
+  name: 'Test Name',
+  desc: 'Test description',
+  labels: ['test', 'label'],
+  dockerImage: 'test/image',
+  dockerTag: 'testTag',
+  runtimePod: 'test pod',
+};
+
+export const runtime2: GetRunningRuntime_runningRuntime = {
+  __typename: 'Runtime',
+  id: 'test 2',
+  name: 'Test Name 2',
+  desc: 'Test description 2',
+  labels: ['test', 'label'],
+  dockerImage: 'test/image2',
+  dockerTag: 'testTag',
+  runtimePod: 'test pod 2',
+};

--- a/app/ui/src/Mocks/entities/user.ts
+++ b/app/ui/src/Mocks/entities/user.ts
@@ -10,6 +10,7 @@ export const userMe = {
   lastActivity: '2020-02-01',
   accessLevel: AccessLevel.ADMIN,
   apiTokens: [apiToken1],
+  isKubeconfigEnabled: true,
 };
 
 export const user1 = {

--- a/app/ui/src/Pages/Project/ProjectContentRoutes.tsx
+++ b/app/ui/src/Pages/Project/ProjectContentRoutes.tsx
@@ -23,13 +23,10 @@ function ProjectContentRoutes({ openedProject }: ProjectRoute) {
   }
 
   function redirectIfToolsActives() {
-    return (
-      !runtimeRunning ||
-      (runtimeLoading !== '' &&
-        [ROUTE.PROJECT_TOOL_JUPYTER, ROUTE.PROJECT_TOOL_VSCODE].map((r) => (
-          <Redirect key={r} from={r} to={ROUTE.PROJECT_OVERVIEW} />
-        )))
-    );
+    if (runtimeRunning && runtimeLoading === '') return;
+    return [ROUTE.PROJECT_TOOL_JUPYTER, ROUTE.PROJECT_TOOL_VSCODE].map((r) => (
+      <Redirect key={r} from={r} to={ROUTE.PROJECT_OVERVIEW} />
+    ));
   }
 
   function redirectDisabledKG() {

--- a/app/ui/src/Pages/Project/ProjectPanels.tsx
+++ b/app/ui/src/Pages/Project/ProjectPanels.tsx
@@ -78,7 +78,7 @@ function ProjectPanels({ openedProject }: Props) {
           <ReactTooltip id="stopPanel" effect="solid" textColor="white" backgroundColor="#888" place="bottom">
             <span>Stop tools</span>
           </ReactTooltip>
-          <div data-tip={true} data-for="stopPanel">
+          <div data-tip={true} data-for="stopPanel" data-testid="panelStopRuntime">
             <Button label="" Icon={IconPause} onClick={pauseRuntime} />
           </div>
         </div>
@@ -89,7 +89,7 @@ function ProjectPanels({ openedProject }: Props) {
           <ReactTooltip id="startPanel" effect="solid" textColor="white" backgroundColor="#888" place="bottom">
             <span>Start tools</span>
           </ReactTooltip>
-          <div data-tip={true} data-for="startPanel">
+          <div data-tip={true} data-for="startPanel" data-testid="panelStartRuntime">
             <Button label="" Icon={IconPlay} onClick={runtimeStart} />
           </div>
         </div>

--- a/app/ui/src/Pages/Project/components/ProjectNavigation/components/NavElements/NavElements.tsx
+++ b/app/ui/src/Pages/Project/components/ProjectNavigation/components/NavElements/NavElements.tsx
@@ -68,7 +68,7 @@ function NavElements({ isOpened }: Props) {
           <span>Stop tools</span>
         </ReactTooltip>
         <div data-tip data-for="stop">
-          <IconPause className={cx(styles.usertoolsIcon, 'icon-small')} onClick={runtimeStop} />
+          <IconPause className={cx(styles.usertoolsIcon, 'icon-small')} onClick={runtimeStop} data-testid="stopTools" />
         </div>
       </div>
     ) : (
@@ -77,7 +77,11 @@ function NavElements({ isOpened }: Props) {
           <span>Start tools</span>
         </ReactTooltip>
         <div data-tip data-for="start">
-          <IconPlay className={cx(styles.usertoolsIcon, 'icon-small')} onClick={runtimeStart} />
+          <IconPlay
+            className={cx(styles.usertoolsIcon, 'icon-small')}
+            onClick={runtimeStart}
+            data-testid="startTools"
+          />
         </div>
       </div>
     );
@@ -120,7 +124,7 @@ function NavElements({ isOpened }: Props) {
               >
                 <span>Show available runtimes</span>
               </ReactTooltip>
-              <div data-tip data-for="settings">
+              <div data-tip data-for="settings" data-testid="openRuntimeSettings">
                 <IconSettings className={cx(styles.usertoolsIcon, 'icon-small')} onClick={toggleUsertoolsPanel} />
               </div>
               {renderToggleToolsIcon()}

--- a/app/ui/src/Pages/Project/components/RuntimeRunner/RuntimeRunner.tsx
+++ b/app/ui/src/Pages/Project/components/RuntimeRunner/RuntimeRunner.tsx
@@ -108,7 +108,7 @@ function RuntimeRunner() {
           blocking
         >
           <ModalLayoutInfo className={styles.runtimeModalInfo}>
-            <div>
+            <div data-testid="stopToolsModal">
               <p>You are going to stop your user tools, please confirm your choice.</p>
               {runtimeRunning && <Runtime runtime={runtimeRunning} runtimeActive={true} disabled={true} />}
             </div>

--- a/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
@@ -16,7 +16,7 @@ function RuntimeInfo({ selectedRuntime: runtime, isKubeconfigEnabled }: Props) {
   return (
     <div>
       <div className={styles.header}>
-        <div data-testid="runtimesListPanel">
+        <div data-testid="runtimeInfoPanel">
           <div className={styles.title}>
             <h1 className={styles.headerName}>{runtime.name}</h1>
             {running && (

--- a/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
@@ -19,7 +19,11 @@ function RuntimeInfo({ selectedRuntime: runtime, isKubeconfigEnabled }: Props) {
         <div data-testid="runtimesListPanel">
           <div className={styles.title}>
             <h1 className={styles.headerName}>{runtime.name}</h1>
-            {running && <div className={styles.runningTag}>Running</div>}
+            {running && (
+              <div className={styles.runningTag} data-testid="statusTag">
+                Running
+              </div>
+            )}
           </div>
           <div className={styles.runtimeTags}>
             <LabelList runtime={runtime} />

--- a/app/ui/src/Pages/Project/panels/RuntimesList/RuntimesList.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/RuntimesList.tsx
@@ -31,7 +31,7 @@ function RuntimesList() {
       </div>
       <div className={styles.runtimeContainer}>
         <div className={styles.runtimeListHeader}>{runtimes.length} RUNTIMES SHOWN</div>
-        <div className={styles.wrapper}>
+        <div className={styles.wrapper} data-testid="runtimesList">
           {[
             ...runtimes.map((runtime) => (
               <Runtime key={runtime.id} runtime={runtime} runtimeActive={runtime.id === runtimeRunning?.id} />

--- a/app/ui/src/Pages/UserKubeconfig/Components/Kubeconfig.tsx
+++ b/app/ui/src/Pages/UserKubeconfig/Components/Kubeconfig.tsx
@@ -23,9 +23,9 @@ function downloadFile(text: string) {
 function Kubeconfig({ kubeconfig }: Props) {
   console.log(kubeconfig);
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid="kubeconfig">
       <div className={styles.kubeconfig}>{kubeconfig.trim()}</div>
-      <div className={styles.buttonsContainer}>
+      <div className={styles.buttonsContainer} data-testid="kubeconfigButtons">
         <Button Icon={IconFileCopy} label="" className={styles.button} onClick={() => copyAndToast(kubeconfig)} />
         <Button Icon={IconGetApp} label="" className={styles.button} onClick={() => downloadFile(kubeconfig)} />
       </div>


### PR DESCRIPTION
Add end-2-end testing to runtimes and kubeconfig functionalities. There is also a small fix, to handle redirects when a user is trying to navigate to the kubeconfig page but the kubeconfig is note enabled.