### PR TITLE
fix scss log on development env

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -86,7 +86,8 @@
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      ">0.3%"
     ]
   },
   "jest": {


### PR DESCRIPTION
This change fixes the log `Greetings, time traveller. We are in the golden age of prefix-less CSS, where Autoprefixer is no longer needed for your stylesheet.`, which appears when start the UI in development.