### PR TITLE
fix(ui): delete areToolsActive references

### DIFF
--- a/app/api/infrastructure/graph/generated/generated.go
+++ b/app/api/infrastructure/graph/generated/generated.go
@@ -153,7 +153,6 @@ type ComplexityRoot struct {
 	User struct {
 		APITokens           func(childComplexity int) int
 		AccessLevel         func(childComplexity int) int
-		AreToolsActive      func(childComplexity int) int
 		CreationDate        func(childComplexity int) int
 		Email               func(childComplexity int) int
 		ID                  func(childComplexity int) int
@@ -211,7 +210,6 @@ type UserResolver interface {
 
 	LastActivity(ctx context.Context, obj *entity.User) (*string, error)
 
-	AreToolsActive(ctx context.Context, obj *entity.User) (bool, error)
 	IsKubeconfigEnabled(ctx context.Context, obj *entity.User) (bool, error)
 }
 
@@ -759,13 +757,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.AccessLevel(childComplexity), true
 
-	case "User.areToolsActive":
-		if e.complexity.User.AreToolsActive == nil {
-			break
-		}
-
-		return e.complexity.User.AreToolsActive(childComplexity), true
-
 	case "User.creationDate":
 		if e.complexity.User.CreationDate == nil {
 			break
@@ -939,7 +930,6 @@ type User {
   accessLevel: AccessLevel!
   lastActivity: String
   apiTokens: [ApiToken!]!
-  areToolsActive: Boolean!
   isKubeconfigEnabled: Boolean!
   sshKey: SSHKey!
 }
@@ -3971,41 +3961,6 @@ func (ec *executionContext) _User_apiTokens(ctx context.Context, field graphql.C
 	return ec.marshalNApiToken2ᚕgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋentityᚐAPITokenᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _User_areToolsActive(ctx context.Context, field graphql.CollectedField, obj *entity.User) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "User",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.User().AreToolsActive(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _User_isKubeconfigEnabled(ctx context.Context, field graphql.CollectedField, obj *entity.User) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -6396,20 +6351,6 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "areToolsActive":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._User_areToolsActive(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
 		case "isKubeconfigEnabled":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -316,12 +316,6 @@ func (r *userResolver) LastActivity(ctx context.Context, obj *entity.User) (*str
 	return &lastActivity, nil
 }
 
-func (r *userResolver) AreToolsActive(ctx context.Context, obj *entity.User) (bool, error) {
-	username := ctx.Value(middleware.LoggedUserNameKey).(string)
-
-	return r.users.AreToolsRunning(ctx, username)
-}
-
 func (r *userResolver) IsKubeconfigEnabled(ctx context.Context, obj *entity.User) (bool, error) {
 	return r.users.IsKubeconfigActive(), nil
 }

--- a/app/graphql/schema.graphqls
+++ b/app/graphql/schema.graphqls
@@ -58,7 +58,6 @@ type User {
   accessLevel: AccessLevel!
   lastActivity: String
   apiTokens: [ApiToken!]!
-  areToolsActive: Boolean!
   isKubeconfigEnabled: Boolean!
   sshKey: SSHKey!
 }

--- a/app/ui/mock-server/src/index.js
+++ b/app/ui/mock-server/src/index.js
@@ -15,12 +15,12 @@ app.use(
 // If you want to simulate a timeout you can uncomment these lines.
 // This function simply generate a random timeout and then it will return the response from the graphQL server.
 // Probably there is a better solution than this, but for dev environment it seems works fine.
-app.use(async (req, __, next) => {
-  const randomWait = casual.integer(2000, 5000);
-  await new Promise((resolve) => setTimeout(resolve, randomWait));
-
-  next();
-});
+// app.use(async (req, __, next) => {
+//   const randomWait = casual.integer(2000, 5000);
+//   await new Promise((resolve) => setTimeout(resolve, randomWait));
+//
+//   next();
+// });
 
 // # This endpoint is used to test unauthorized response
 // app.post('/graphql', (req, res) => {

--- a/app/ui/mock-server/src/mocks/meMock.js
+++ b/app/ui/mock-server/src/mocks/meMock.js
@@ -6,7 +6,6 @@ const me = {
   id: meId,
   email: 'admin@intelygenz.com',
   username: 'admin',
-  areToolsActive: true,
   apiTokens: () => new MockList([4, 8]),
   accessLevel: 'ADMIN',
   isKubeconfigEnabled: true,

--- a/app/ui/src/Graphql/mutations/setActiveUserTools.ts
+++ b/app/ui/src/Graphql/mutations/setActiveUserTools.ts
@@ -4,7 +4,6 @@ export default gql`
   mutation SetActiveUserTools($input: SetActiveUserToolsInput!) {
     setActiveUserTools(input: $input) {
       id
-      areToolsActive
     }
   }
 `;

--- a/app/ui/src/Graphql/mutations/types/SetActiveUserTools.ts
+++ b/app/ui/src/Graphql/mutations/types/SetActiveUserTools.ts
@@ -12,7 +12,6 @@ import { SetActiveUserToolsInput } from "./../../types/globalTypes";
 export interface SetActiveUserTools_setActiveUserTools {
   __typename: "User";
   id: string;
-  areToolsActive: boolean;
 }
 
 export interface SetActiveUserTools {

--- a/app/ui/src/Graphql/queries/getMe.ts
+++ b/app/ui/src/Graphql/queries/getMe.ts
@@ -5,7 +5,6 @@ export default gql`
     me {
       id
       email
-      areToolsActive
       isKubeconfigEnabled
       accessLevel
       apiTokens {

--- a/app/ui/src/Graphql/queries/getUserTools.ts
+++ b/app/ui/src/Graphql/queries/getUserTools.ts
@@ -16,7 +16,6 @@ export default gql`
     }
     me {
       id
-      areToolsActive
     }
   }
 `;

--- a/app/ui/src/Graphql/queries/types/GetMe.ts
+++ b/app/ui/src/Graphql/queries/types/GetMe.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import {AccessLevel} from "../../types/globalTypes";
+import { AccessLevel } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: GetMe
@@ -21,7 +21,6 @@ export interface GetMe_me {
   __typename: "User";
   id: string;
   email: string;
-  areToolsActive: boolean;
   isKubeconfigEnabled: boolean;
   accessLevel: AccessLevel;
   apiTokens: GetMe_me_apiTokens[];

--- a/app/ui/src/Graphql/queries/types/GetUserTools.ts
+++ b/app/ui/src/Graphql/queries/types/GetUserTools.ts
@@ -27,7 +27,6 @@ export interface GetUserTools_project {
 export interface GetUserTools_me {
   __typename: "User";
   id: string;
-  areToolsActive: boolean;
 }
 
 export interface GetUserTools {

--- a/app/ui/src/Mocks/entities/user.ts
+++ b/app/ui/src/Mocks/entities/user.ts
@@ -4,7 +4,6 @@ import { AccessLevel } from '../../Graphql/types/globalTypes';
 export const userMe = {
   id: 'userMe',
   email: 'admin@konstellation.io',
-  areToolsActive: true,
   username: 'userMe',
   creationDate: '2020-02-01',
   lastActivity: '2020-02-01',

--- a/app/ui/src/Pages/UserSshKey/UserSshKey.tsx
+++ b/app/ui/src/Pages/UserSshKey/UserSshKey.tsx
@@ -1,22 +1,20 @@
 import { ErrorMessage, SpinnerCircular } from 'kwc';
 import FAQBox, { BOX_THEME } from './components/FAQBox/FAQBox';
 
-import { GetMe } from 'Graphql/queries/types/GetMe';
 import { GetSSHKey } from 'Graphql/queries/types/GetSSHKey';
 import * as React from 'react';
 import SSHKey from './components/SSHKey/SSHKey';
 import { copyAndToast } from 'Utils/clipboard';
 import styles from './UserSshKey.module.scss';
 import { toast } from 'react-toastify';
-import { useQuery } from '@apollo/client';
+import { useQuery, useReactiveVar } from '@apollo/client';
 import useSSHKey from 'Graphql/hooks/useSSHKey';
 
 import GetSSHKeys from 'Graphql/queries/getSSHKey';
-import GetMeQuery from 'Graphql/queries/getMe';
+import { runningRuntime } from '../../Graphql/client/cache';
 
 function UserSshKey() {
   const { data, loading, error } = useQuery<GetSSHKey>(GetSSHKeys);
-  const { data: dataMe } = useQuery<GetMe>(GetMeQuery);
   const {
     regenerateSSHKey: { performMutation: regenerateSSHKey, loading: regenerateSSHKeyLoading },
   } = useSSHKey({
@@ -26,7 +24,7 @@ function UserSshKey() {
     },
   });
 
-  const userToolsRunning = !!dataMe?.me.areToolsActive;
+  const runtimeRunning = useReactiveVar(runningRuntime);
 
   function getContent() {
     if (loading) return <SpinnerCircular />;
@@ -75,7 +73,7 @@ function UserSshKey() {
                 action). You will not be able to access repositories with the old SSH Key, and you cannot recover previous
                 SSH keys, so be sure to update the key on all the services you will continue using."
               customAction={
-                userToolsRunning ? (
+                runtimeRunning ? (
                   <div className={styles.regenWarning}>
                     <div className={styles.regenWarningTag}>WARNING:</div>
                     <div className={styles.regenWarningText}>


### PR DESCRIPTION
The User field areToolsActive was used to check if user tools were active. With the runtimes changes, the query GetRunningRuntime is the responsible for this, so areToolsActive is not used anymore.
This changes delete this field from graphql schema, and from the API and UI code.