### PR TITLE
fix: kubeconfig username slug

### DIFF
--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/gosimple/slug"
+
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
@@ -342,5 +344,7 @@ func (i *interactor) GetKubeconfig(ctx context.Context, username string) (string
 		return "", ErrStopUserTools
 	}
 
-	return i.k8sClient.GetUserKubeconfigSecret(ctx, username)
+	usernameSlug := slug.Make(username)
+
+	return i.k8sClient.GetUserKubeconfigSecret(ctx, usernameSlug)
 }

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosimple/slug"
+
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
@@ -557,14 +559,17 @@ func TestInteractor_GetKubeconfig(t *testing.T) {
 	defer s.ctrl.Finish()
 
 	const (
-		username       = "john"
+		username       = "john.doe"
 		areToolsActive = true
 	)
 
 	ctx := context.Background()
 	expectedKubeconfig := "Test Kubeconfig"
 
-	s.mocks.k8sClientMock.EXPECT().GetUserKubeconfigSecret(ctx, username).Return(expectedKubeconfig, nil)
+	// the secret must use the username slug instead of the username
+	usernameSlug := slug.Make(username)
+
+	s.mocks.k8sClientMock.EXPECT().GetUserKubeconfigSecret(ctx, usernameSlug).Return(expectedKubeconfig, nil)
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).Return(areToolsActive, nil)
 
 	returnedKubeconfig, err := s.interactor.GetKubeconfig(ctx, username)

--- a/helm/kdl-server/Chart.yaml
+++ b/helm/kdl-server/Chart.yaml
@@ -3,7 +3,7 @@ name: kdl-server
 description: KDL server
 
 type: application
-version: 1.0-rc.4
+version: 1.0.0
 appVersion: 1.3.0
 dependencies:
   - name: minio


### PR DESCRIPTION
Use username slug instead of username when retrieving the kubeconfig secret.