### PR TITLE
fix(helm): backup cronjob activeDeadlineSeconds and backoffLimit values are hardcoded

### DIFF
--- a/helm/kdl-server/templates/common/backup-cronjob.yaml
+++ b/helm/kdl-server/templates/common/backup-cronjob.yaml
@@ -15,8 +15,8 @@ spec:
     metadata:
       name: {{ .Values.backup.name }}
     spec:
-      backoffLimit: 3
-      activeDeadlineSeconds: 60 # 1min
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
       template:
         spec:
           securityContext:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -10,10 +10,25 @@ backup:
     repository: konstellation/kdl-backup
     tag: v0.17.0
     pullPolicy: IfNotPresent
+
+  ## Sets the activeDeadlineSeconds param for the backup cronjob
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup
+  ##
+  activeDeadlineSeconds: 3600
+
+  ## Sets tge backoffLimit param for the backup cronjob
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+  ##
+  backoffLimit: 3
+
   s3:
     awsAccessKeyID: aws-access-key-id
     awsSecretAccessKey: aws-secret-access-key
     bucketName: s3-bucket-name
+
+  ## Resource requests and limits for backup container
+  ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  ##
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
`activeDeadlineSeconds` is hardcoded to 60 (1min) so backup cronjob always fails for big backups.

Now `activeDeadlineSeconds` and `backoffLimit` are set from **values.yaml** file.