### PR TITLE
fix: fixes from v1.0.0

### DIFF
--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/gosimple/slug"
+
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
@@ -342,5 +344,7 @@ func (i *interactor) GetKubeconfig(ctx context.Context, username string) (string
 		return "", ErrStopUserTools
 	}
 
-	return i.k8sClient.GetUserKubeconfigSecret(ctx, username)
+	usernameSlug := slug.Make(username)
+
+	return i.k8sClient.GetUserKubeconfigSecret(ctx, usernameSlug)
 }

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosimple/slug"
+
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
@@ -557,14 +559,17 @@ func TestInteractor_GetKubeconfig(t *testing.T) {
 	defer s.ctrl.Finish()
 
 	const (
-		username       = "john"
+		username       = "john.doe"
 		areToolsActive = true
 	)
 
 	ctx := context.Background()
 	expectedKubeconfig := "Test Kubeconfig"
 
-	s.mocks.k8sClientMock.EXPECT().GetUserKubeconfigSecret(ctx, username).Return(expectedKubeconfig, nil)
+	// the secret must use the username slug instead of the username
+	usernameSlug := slug.Make(username)
+
+	s.mocks.k8sClientMock.EXPECT().GetUserKubeconfigSecret(ctx, usernameSlug).Return(expectedKubeconfig, nil)
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).Return(areToolsActive, nil)
 
 	returnedKubeconfig, err := s.interactor.GetKubeconfig(ctx, username)

--- a/helm/kdl-server/templates/common/backup-cronjob.yaml
+++ b/helm/kdl-server/templates/common/backup-cronjob.yaml
@@ -52,21 +52,15 @@ spec:
               volumeMounts:
               - name: gitea-pvc
                 mountPath: "/data"
-          {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 12 }}
-          {{- end }}
-          {{- if .Values.imagePullSecrets }}
-          imagePullSecrets:
-          {{- range .Values.imagePullSecrets  }}
-          - name: {{ . }}
-          {{- end }}
-          {{- end }}
+            {{- with .Values.backup.extraVolumeMounts }}
+{{ toYaml . | indent 14 }}
+            {{- end }}
           volumes:
             - name: gitea-pvc
               persistentVolumeClaim:
                 claimName: gitea-pvc-gitea-0
-            {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 12 }}
-      {{- end }}
+            {{- with .Values.backup.extraVolumes }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
           restartPolicy: OnFailure
 {{- end }}

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -36,6 +36,7 @@ backup:
     limits:
       cpu: "100m"
       memory: "256Mi"
+
   extraVolumeMounts: []
   # extraVolumeMounts:
   #   - name: shared-storage

--- a/user-tools-operator/helm-charts/usertools/templates/kubeconfig-tpl-configmap.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/kubeconfig-tpl-configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubeconfig-tpl-configmap
+  name: kubeconfig-{{ .Values.usernameSlug }}-tpl-configmap
   labels:
-    app: kubeconfig-tpl-configmap
+    app: kubeconfig-{{ .Values.usernameSlug }}-tpl-configmap
 data:
 
   generate-kubeconfig.sh: |+

--- a/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
@@ -250,7 +250,7 @@ spec:
       volumes:
         - name: kubeconfig-tpl-configmap
           configMap:
-            name: kubeconfig-tpl-configmap
+            name: kubeconfig-{{ .Values.usernameSlug }}-tpl-configmap
         - name: oauth2-config
           configMap:
             name: {{ include "user-tools.fullname" . }}-oauth2-proxy


### PR DESCRIPTION
Cherry pick fixes from v1.0.0 into main

- Kubeconfig-tpl-configmap namming
- Use username-slug to retrieve kubeconfig secrets
- Activate and fix backups