### PR TITLE
FIX: MinIO programatic service access

### DIFF
--- a/helm/kdl-server/templates/minio/ingress-minio-console.yml
+++ b/helm/kdl-server/templates/minio/ingress-minio-console.yml
@@ -1,0 +1,40 @@
+{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end }}
+kind: Ingress
+metadata:
+  name: minio-console
+  annotations:
+    {{ if eq .Values.ingress.type "nginx" }}
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+    {{ end }}
+spec:
+  {{ if .Values.tls.enabled -}}
+  tls:
+    - hosts:
+        - minio-console.{{ .Values.domain }}
+      secretName: {{ .Values.domain }}-tls-secret
+  {{- end }}
+  rules:
+    - host: minio-console.{{ .Values.domain }}
+      http:
+        paths:
+          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: {{ .Release.Name }}-minio-console
+                port:
+                  number: 9001
+          {{ else }}
+          - path: /
+            backend:
+              serviceName: {{ .Release.Name }}-minio-console
+              servicePort: 9001
+          {{ end }}

--- a/helm/kdl-server/templates/minio/ingress-minio.yaml
+++ b/helm/kdl-server/templates/minio/ingress-minio.yaml
@@ -29,12 +29,12 @@ spec:
             path: "/"
             backend:
               service:
-                name: {{ .Release.Name }}-minio-console
+                name: {{ .Release.Name }}-minio
                 port:
-                  number: 9001
+                  number: 9000
           {{ else }}
           - path: /
             backend:
-              serviceName: {{ .Release.Name }}-minio-console
-              servicePort: 9001
+              serviceName: {{ .Release.Name }}-minio
+              servicePort: 9000
           {{ end }}


### PR DESCRIPTION
Fixes the credentials issue when trying to access MinIO service through the current ingress.

Added:
* New `minio-console` ingress for MinIO console access

Fixes:
* `minio` ingress now points to the programmatic access service endpoint