### PR TITLE
fix(ui): avoid replacement modal when navigating to project

### DIFF
--- a/app/ui/src/Pages/Project/components/RuntimeRunner/RuntimeRunner.tsx
+++ b/app/ui/src/Pages/Project/components/RuntimeRunner/RuntimeRunner.tsx
@@ -65,6 +65,7 @@ function RuntimeRunner() {
 
   //decide whether start the tools or show the replace modal
   function handleStartTools() {
+    if (runtimeAction?.runtime?.id === runtimeRunning?.id) return;
     if (!runtimeAction?.runtime) {
       // if starting the tools and runtime is NOT selected
       return openRuntimesList();


### PR DESCRIPTION
Fix the replacement modal that appears when navigates to a projects that already have a runtime running. When trying to replace a runtime with the same runtime, does anything.