### PR TITLE
feat: document full kubeconfig instructions

### DIFF
--- a/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.module.scss
+++ b/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.module.scss
@@ -24,5 +24,10 @@
     .highlight {
       color: font-color(light);
     }
+
+    .link {
+      color: font-color(light);
+      text-decoration: underline;
+    }
   }
 }

--- a/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.tsx
+++ b/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.tsx
@@ -25,7 +25,33 @@ function UserKubeconfig() {
         extension in VSCode.
         <p>
           <ol>
-            <li>Download the kube config and configure it in the Kubernetes extension.</li>
+            <li>
+              Install the{' '}
+              <a
+                target="_blank"
+                href="https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools"
+                rel="noreferrer"
+                className={styles.link}
+              >
+                Kubernetes Extension.
+              </a>
+            </li>
+            <li>
+              Install the{' '}
+              <a
+                target="_blank"
+                href="https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack"
+                rel="noreferrer"
+                className={styles.link}
+              >
+                Remote Development Extension Pack.
+              </a>
+            </li>
+            <li>Download the kube config shown in this page.</li>
+            <li>
+              Move the downloaded kube config file to <span className={styles.highlight}>~/.kube/config</span>
+            </li>
+            <li>Configure the kube config file in the kubernetes extension.</li>
             <li>In the kubernetes extension, navigate to &ldquo;Workloads &gt; Pods&ldquo;</li>
             <li>
               Locate the runtime pod named <span className={styles.highlight}>usertools-#USERNAME#-user-tools-0</span>,


### PR DESCRIPTION
Complete the instructions to use the external kubeconfig file in local VSCode. 

closes #744 