### PR TITLE
feat(api): create service accounts from app

### DIFF
--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -80,24 +80,7 @@ func main() {
 	}
 
 	userInteractor := user.NewInteractor(logger, cfg, userRepo, runtimeRepo, sshHelper, realClock, giteaService, k8sClient)
-
-	err = userInteractor.CreateAdminUser(cfg.Admin.Username, cfg.Admin.Email)
-	if err != nil {
-		logger.Errorf("Unexpected error creating admin user: %s", err)
-
-		defer os.Exit(1)
-
-		return
-	}
-
-	err = userInteractor.ScheduleUsersSyncJob(cfg.ScheduledJob.UsersSync.Interval)
-	if err != nil {
-		logger.Errorf("Unexpected error creating scheduled job for users synchronization: %s", err)
-
-		defer os.Exit(1)
-
-		return
-	}
+	initUserInteractor(userInteractor, cfg, logger)
 
 	projectDeps := &project.InteractorDeps{
 		Logger:       logger,
@@ -123,6 +106,35 @@ func main() {
 	)
 
 	startHTTPServer(logger, cfg.Port, cfg.StaticFilesPath, cfg.Kubernetes.IsInsideCluster, resolvers, userRepo, projectRepo)
+}
+
+func initUserInteractor(userInteractor user.UseCase, cfg config.Config, logger logging.Logger) {
+	err := userInteractor.CreateAdminUser(cfg.Admin.Username, cfg.Admin.Email)
+	if err != nil {
+		logger.Errorf("Unexpected error creating admin user: %s", err)
+
+		defer os.Exit(1)
+
+		return
+	}
+
+	err = userInteractor.ScheduleUsersSyncJob(cfg.ScheduledJob.UsersSync.Interval)
+	if err != nil {
+		logger.Errorf("Unexpected error creating scheduled job for users synchronization: %s", err)
+
+		defer os.Exit(1)
+
+		return
+	}
+
+	err = userInteractor.CreateMissingServiceAccountsForUsers()
+	if err != nil {
+		logger.Errorf("Unexpected error creating serviceAccount for users: %s", err)
+
+		defer os.Exit(1)
+
+		return
+	}
 }
 
 func startHTTPServer(

--- a/app/api/infrastructure/k8s/interface.go
+++ b/app/api/infrastructure/k8s/interface.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"context"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/konstellation-io/kdl-server/app/api/entity"
 )
 
@@ -22,5 +24,7 @@ type Client interface {
 	UpdateUserSSHKeySecret(ctx context.Context, user entity.User, public, private string) error
 	GetUserSSHKeySecret(ctx context.Context, usernameSlug string) ([]byte, error)
 	GetUserSSHKeyPublic(ctx context.Context, usernameSlug string) ([]byte, error)
-	GetUserKubeconfigSecret(ctx context.Context, usernameSlug string) (string, error)
+	CreateUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error)
+	GetUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error)
+	GetUserKubeconfig(ctx context.Context, usernameSlug string) ([]byte, error)
 }

--- a/app/api/infrastructure/k8s/kubeconfig.go
+++ b/app/api/infrastructure/k8s/kubeconfig.go
@@ -2,24 +2,81 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+	"encoding/base64"
+	"errors"
+
+	v1 "k8s.io/api/core/v1"
 )
 
-const (
-	kubeconfigSecretKey = "kubeconfig"
+var (
+	ErrNoSecretInServiceAccount      = errors.New("no secrets found in the serviceAccount")
+	ErrReadingSecretInServiceAccount = errors.New("error reading secret in in the serviceAccount")
 )
 
-// getUserKubeconfigSecretName returns the name of the kubeconfig secret for a given user.
-func (k k8sClient) getUserKubeconfigSecretName(usernameSlug string) string {
-	return fmt.Sprintf("%s-kubeconfig", usernameSlug)
-}
+func (k *k8sClient) extractServiceAccountSecretInfo(ctx context.Context, serviceAccount *v1.ServiceAccount) (ca, token []byte, err error) {
+	secrets := serviceAccount.Secrets
 
-// GetUserKubeconfigSecret returns kubeconfig for the given user.
-func (k *k8sClient) GetUserKubeconfigSecret(ctx context.Context, usernameSlug string) (string, error) {
-	kubeconfigSecret, err := k.GetSecret(ctx, k.getUserKubeconfigSecretName(usernameSlug))
-	if err != nil {
-		return "", err
+	if len(secrets) == 0 {
+		return nil, nil, ErrNoSecretInServiceAccount
 	}
 
-	return string(kubeconfigSecret[kubeconfigSecretKey]), nil
+	secretName := secrets[0].Name
+
+	secret, err := k.GetSecret(ctx, secretName)
+	if err != nil {
+		k.logger.Infof("error retrieving secret \"%s\"", secretName)
+		return nil, nil, ErrReadingSecretInServiceAccount
+	}
+
+	ca = secret[v1.ServiceAccountRootCAKey]
+	token = secret[v1.ServiceAccountTokenKey]
+
+	return ca, token, nil
+}
+
+// generateKubeconfig generate a kubeconfig file in a string.
+func (k *k8sClient) generateKubeconfig(ctx context.Context, serviceAccount *v1.ServiceAccount) ([]byte, error) {
+	ca, token, err := k.extractServiceAccountSecretInfo(ctx, serviceAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfig := []byte(`
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ` + base64.StdEncoding.EncodeToString(ca) + `
+    server: ` + k.cfg.UserToolsKubeconfig.ExternalServerURL + `
+  name: konstellation
+contexts:
+- context:
+    cluster: konstellation
+    user: coder
+    namespace: ` + k.cfg.Kubernetes.Namespace + `
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: coder
+  user:
+    token: ` + string(token) + `
+`)
+
+	return kubeconfig, nil
+}
+
+// GetUserKubeconfig get a user kubeconfig string in k8s.
+func (k *k8sClient) GetUserKubeconfig(ctx context.Context, usernameSlug string) ([]byte, error) {
+	serviceAccount, err := k.GetUserServiceAccount(ctx, usernameSlug)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfig, err := k.generateKubeconfig(ctx, serviceAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeconfig, nil
 }

--- a/app/api/infrastructure/k8s/mocks_interface.go
+++ b/app/api/infrastructure/k8s/mocks_interface.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	entity "github.com/konstellation-io/kdl-server/app/api/entity"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockClient is a mock of Client interface.
@@ -77,6 +78,21 @@ func (mr *MockClientMockRecorder) CreateUserSSHKeySecret(ctx, user, public, priv
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserSSHKeySecret", reflect.TypeOf((*MockClient)(nil).CreateUserSSHKeySecret), ctx, user, public, private)
 }
 
+// CreateUserServiceAccount mocks base method.
+func (m *MockClient) CreateUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUserServiceAccount", ctx, usernameSlug)
+	ret0, _ := ret[0].(*v1.ServiceAccount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUserServiceAccount indicates an expected call of CreateUserServiceAccount.
+func (mr *MockClientMockRecorder) CreateUserServiceAccount(ctx, usernameSlug interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserServiceAccount", reflect.TypeOf((*MockClient)(nil).CreateUserServiceAccount), ctx, usernameSlug)
+}
+
 // CreateUserToolsCR mocks base method.
 func (m *MockClient) CreateUserToolsCR(ctx context.Context, username, runtimeID, runtimeImage, runtimeTag string) error {
 	m.ctrl.T.Helper()
@@ -135,19 +151,19 @@ func (mr *MockClientMockRecorder) GetSecret(ctx, name interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockClient)(nil).GetSecret), ctx, name)
 }
 
-// GetUserKubeconfigSecret mocks base method.
-func (m *MockClient) GetUserKubeconfigSecret(ctx context.Context, usernameSlug string) (string, error) {
+// GetUserKubeconfig mocks base method.
+func (m *MockClient) GetUserKubeconfig(ctx context.Context, usernameSlug string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserKubeconfigSecret", ctx, usernameSlug)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetUserKubeconfig", ctx, usernameSlug)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUserKubeconfigSecret indicates an expected call of GetUserKubeconfigSecret.
-func (mr *MockClientMockRecorder) GetUserKubeconfigSecret(ctx, usernameSlug interface{}) *gomock.Call {
+// GetUserKubeconfig indicates an expected call of GetUserKubeconfig.
+func (mr *MockClientMockRecorder) GetUserKubeconfig(ctx, usernameSlug interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserKubeconfigSecret", reflect.TypeOf((*MockClient)(nil).GetUserKubeconfigSecret), ctx, usernameSlug)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserKubeconfig", reflect.TypeOf((*MockClient)(nil).GetUserKubeconfig), ctx, usernameSlug)
 }
 
 // GetUserSSHKeyPublic mocks base method.
@@ -178,6 +194,21 @@ func (m *MockClient) GetUserSSHKeySecret(ctx context.Context, usernameSlug strin
 func (mr *MockClientMockRecorder) GetUserSSHKeySecret(ctx, usernameSlug interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSSHKeySecret", reflect.TypeOf((*MockClient)(nil).GetUserSSHKeySecret), ctx, usernameSlug)
+}
+
+// GetUserServiceAccount mocks base method.
+func (m *MockClient) GetUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserServiceAccount", ctx, usernameSlug)
+	ret0, _ := ret[0].(*v1.ServiceAccount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserServiceAccount indicates an expected call of GetUserServiceAccount.
+func (mr *MockClientMockRecorder) GetUserServiceAccount(ctx, usernameSlug interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserServiceAccount", reflect.TypeOf((*MockClient)(nil).GetUserServiceAccount), ctx, usernameSlug)
 }
 
 // IsUserToolPODRunning mocks base method.

--- a/app/api/infrastructure/k8s/service_account.go
+++ b/app/api/infrastructure/k8s/service_account.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newServiceAccount conform a new k8s serviceAccount.
+func (k *k8sClient) newServiceAccount(usernameSlug string) *v1.ServiceAccount {
+	return &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: k.getUserServiceAccountName(usernameSlug)}}
+}
+
+// getUserServiceAccountName returns the name of the service account for a given user.
+func (k k8sClient) getUserServiceAccountName(usernameSlug string) string {
+	return fmt.Sprintf("%s-service-account", usernameSlug)
+}
+
+// CreateUserServiceAccount creates a new k8s serviceAccount for a user.
+func (k *k8sClient) CreateUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error) {
+	k.logger.Infof("Creating service account for user \"%s\" in k8s...", usernameSlug)
+
+	sa := k.newServiceAccount(usernameSlug)
+
+	serviceAccount, err := k.clientset.CoreV1().ServiceAccounts(k.cfg.Kubernetes.Namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	k.logger.Infof("The service account \"%s\" was created in k8s correctly", serviceAccount.Name)
+
+	return serviceAccount, nil
+}
+
+// GetUserServiceAccount returns the serviceAccount for the given user.
+func (k *k8sClient) GetUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error) {
+	serviceAccountName := k.getUserServiceAccountName(usernameSlug)
+
+	serviceAccount, err := k.clientset.CoreV1().ServiceAccounts(k.cfg.Kubernetes.Namespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return serviceAccount, nil
+}

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -175,8 +175,9 @@ func (k *k8sClient) createToolSecret(ctx context.Context, slugUsername, toolName
 }
 
 // createUserToolsDefinition creates a new Custom Resource of type UserTools for the given user.
-func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, slugUsername, resName, runtimeID,
+func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, usernameSlug, resName, runtimeID,
 	runtimeImage, runtimeTag string) error {
+	serviceAccountName := k.getUserServiceAccountName(usernameSlug)
 	definition := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "UserTools",
@@ -194,7 +195,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, slu
 					"type": k.cfg.VSCode.Ingress.Type,
 				},
 				"username":     username,
-				"usernameSlug": slugUsername,
+				"usernameSlug": usernameSlug,
 				"storage": map[string]string{
 					"size":      k.cfg.Storage.Size,
 					"className": k.cfg.Storage.ClassName,
@@ -251,6 +252,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, slu
 						"pullPolicy": k.cfg.UserToolsVsCodeRuntime.Image.PullPolicy,
 					},
 				},
+				"serviceAccountName": serviceAccountName,
 			},
 		},
 	}

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -363,7 +363,6 @@ func (i *interactor) CreateAdminUser(username, email string) error {
 // GetKubeconfig returns user kubeconfig.
 func (i *interactor) GetKubeconfig(ctx context.Context, username string) (string, error) {
 	running, err := i.k8sClient.IsUserToolPODRunning(ctx, username)
-	i.logger.Debugf("User \"%s\" Tools active \"%s\"", running)
 
 	if err != nil {
 		return "", err

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -41,4 +41,5 @@ type UseCase interface {
 	ScheduleUsersSyncJob(interval time.Duration) error
 	RunSyncUsersCronJob()
 	GetKubeconfig(ctx context.Context, username string) (string, error)
+	CreateMissingServiceAccountsForUsers() error
 }

--- a/app/api/usecase/user/mocks_interface.go
+++ b/app/api/usecase/user/mocks_interface.go
@@ -263,6 +263,20 @@ func (mr *MockUseCaseMockRecorder) CreateAdminUser(username, email interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAdminUser", reflect.TypeOf((*MockUseCase)(nil).CreateAdminUser), username, email)
 }
 
+// CreateMissingServiceAccountsForUsers mocks base method.
+func (m *MockUseCase) CreateMissingServiceAccountsForUsers() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateMissingServiceAccountsForUsers")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateMissingServiceAccountsForUsers indicates an expected call of CreateMissingServiceAccountsForUsers.
+func (mr *MockUseCaseMockRecorder) CreateMissingServiceAccountsForUsers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMissingServiceAccountsForUsers", reflect.TypeOf((*MockUseCase)(nil).CreateMissingServiceAccountsForUsers))
+}
+
 // FindAll mocks base method.
 func (m *MockUseCase) FindAll(ctx context.Context) ([]entity.User, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
With this commit, the KdlApp is the responsible for generating and mantaining the ServiceAccounts for the users. It checks and generate the ServiceAccounts at application startup.

When generating the kubeconfig for the users, use the user ServiceAccount to build the kubeconfig file live, instead of taking them from the kubeconfig secret.

updates #741 