### PR TITLE
feat(usertools-operator): remove serviceaccount

### DIFF
--- a/user-tools-operator/helm-charts/usertools/templates/kubeconfig-tpl-configmap.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/kubeconfig-tpl-configmap.yaml
@@ -16,8 +16,6 @@ data:
       exit 0
     fi
 
-    SECRETNAME={{ .Values.usernameSlug }}-kubeconfig
-    EXTERNAL_URL={{ .Values.kubeconfig.externalServerUrl }}
     INTERNAL_URL=https://kubernetes.default.svc
     CACERT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 | tr -d '\n')
     TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
@@ -36,15 +34,6 @@ data:
     mkdir -p ${KUBECONFIG_DIR}
     replace_template ${KUBECONFIG_DIR}/config ${INTERNAL_URL}
     chown -R 1000:1000 ${KUBECONFIG_DIR}
-
-    replace_template /tmp/kubeconfig ${EXTERNAL_URL}
-
-    kubectl delete secret ${SECRETNAME} --ignore-not-found
-    kubectl create secret generic ${SECRETNAME} \
-      --save-config \
-      --dry-run=client \
-      --from-file=/tmp/kubeconfig \
-      -o yaml | kubectl apply -n {{ .Release.Namespace }} -f -
 
   kubeconfig.tpl: |+
     apiVersion: v1

--- a/user-tools-operator/helm-charts/usertools/templates/rbac.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: user-tools-{{ .Values.usernameSlug }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -39,7 +34,7 @@ metadata:
   name: user-tools-{{ .Values.usernameSlug }}
 subjects:
 - kind: ServiceAccount
-  name: user-tools-{{ .Values.usernameSlug }}
+  name: {{ .Values.serviceAccountName }}
 roleRef:
   kind: Role
   name: user-tools-{{ .Values.usernameSlug }}

--- a/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      serviceAccountName: "user-tools-{{ .Values.usernameSlug }}"
+      serviceAccountName: {{ .Values.userServiceAccountName }}
       securityContext:
         fsGroup: 1000
       initContainers:

--- a/user-tools-operator/helm-charts/usertools/values.yaml
+++ b/user-tools-operator/helm-charts/usertools/values.yaml
@@ -41,6 +41,9 @@ username: user.name
 
 usernameSlug: user-name
 
+## The service account for the user that owns the user-tools
+serviceAccountName: default
+
 ## If enabled, users will be able to download a kubeconfig file, so they can attach an external terminal/IDE to
 ## the vscodeRuntime running inside KST.
 kubeconfig:


### PR DESCRIPTION
Remove the service account that was tied to the usertools. The service account was being created/deleted with the users tools start/stop. We want that each user has a single serviceAccount that is not tied to the life-cycle of the usertools.

updates #741 