### PR TITLE
fix(ui): allow back navigation from setting pages

### DIFF
--- a/app/ui/cypress/integration/kubeconfig.spec.ts
+++ b/app/ui/cypress/integration/kubeconfig.spec.ts
@@ -1,6 +1,8 @@
 import GetMeQuery from '../../src/Mocks/GetMeQuery';
 import GetRuntimesQuery from '../../src/Mocks/GetRuntimesQuery';
 import { join } from 'path';
+import GetProjectsQuery from '../../src/Mocks/GetProjectsQuery';
+import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
 
 describe('Kubeconfig Pages Behavior', () => {
   beforeEach(() => {
@@ -77,5 +79,23 @@ describe('Kubeconfig Pages Behavior', () => {
     // THEN the kubeconfig should be downloaded
     const downloadFolder = Cypress.config('downloadsFolder');
     cy.readFile(join(downloadFolder, 'kubeconfig')).should('exist');
+  });
+
+  it('should go back when click on back arrow', () => {
+    // GIVEN there is a list of projects
+    cy.kstInterceptor('GetProjects', { data: GetProjectsQuery });
+    // and a runtime is running
+    cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+    // and we navigate to kubeconfig from the settings crumb
+    cy.visit('http://localhost:3001');
+    cy.getByTestId('project').first().parent().click();
+    cy.getByTestId('settingsCrumb').click();
+    cy.contains('Kubeconfig').click();
+
+    // WHEN the arrow button in the left of the title is clicked
+    cy.getByTestId('userPageHeader').children().first().click();
+
+    // THEN it should navigate to the previous page
+    cy.url().should('contain', '/overview');
   });
 });

--- a/app/ui/src/Components/SettingsMenu/SettingsMenu.tsx
+++ b/app/ui/src/Components/SettingsMenu/SettingsMenu.tsx
@@ -70,7 +70,7 @@ function SettingsMenu() {
   };
 
   return (
-    <div>
+    <div data-testid="settingsCrumb">
       <Select
         label=""
         placeholder={data?.me?.email}

--- a/app/ui/src/Components/SettingsMenu/__snapshots__/SettingsMenu.test.tsx.snap
+++ b/app/ui/src/Components/SettingsMenu/__snapshots__/SettingsMenu.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`When data is ready should render without crashing 1`] = `
 <body>
   <div>
-    <div>
+    <div
+      data-testid="settingsCrumb"
+    >
       <div
         class="settings _2rBeV _1z7Bn"
       >

--- a/app/ui/src/Components/UserPageHeader/UserPageHeader.module.scss
+++ b/app/ui/src/Components/UserPageHeader/UserPageHeader.module.scss
@@ -1,0 +1,28 @@
+@import 'Styles/variables';
+@import 'Styles/colors';
+
+.containerHeader {
+  display: flex;
+
+  .title {
+    color: font-color(lowlight);
+    line-height: 8 * $grid-unit;
+    text-align: left;
+
+    padding-left: 3 * $grid-unit;
+    background-color: palette(base, 600);
+    padding-left: 2 * $grid-unit;
+
+  }
+  .goBackButton {
+    color: font-color(lowlight);
+    height: 100%;
+    align-self: center;
+    margin-left: 2 * $grid-unit;
+    cursor: pointer;
+    &:hover,
+    &:focus {
+      color: white;
+    }
+  }
+}

--- a/app/ui/src/Components/UserPageHeader/UserPageHeader.tsx
+++ b/app/ui/src/Components/UserPageHeader/UserPageHeader.tsx
@@ -15,7 +15,7 @@ const UserPageHeader = ({ title }: Props) => {
   };
 
   return (
-    <div className={styles.containerHeader}>
+    <div className={styles.containerHeader} data-testid="userPageHeader">
       <ArrowBackIcon onClick={goBack} className={styles.goBackButton} fontSize="small" />
       <h1 className={styles.title}>{title}</h1>
     </div>

--- a/app/ui/src/Components/UserPageHeader/UserPageHeader.tsx
+++ b/app/ui/src/Components/UserPageHeader/UserPageHeader.tsx
@@ -1,0 +1,25 @@
+import styles from './UserPageHeader.module.scss';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+
+type Props = {
+  title: string;
+};
+
+const UserPageHeader = ({ title }: Props) => {
+  const history = useHistory();
+
+  const goBack = () => {
+    history.goBack();
+  };
+
+  return (
+    <div className={styles.containerHeader}>
+      <ArrowBackIcon onClick={goBack} className={styles.goBackButton} fontSize="small" />
+      <h1 className={styles.title}>{title}</h1>
+    </div>
+  );
+};
+
+export default UserPageHeader;

--- a/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.module.scss
+++ b/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.module.scss
@@ -6,13 +6,6 @@
   overflow: auto;
   padding-bottom: 10 * $grid-unit;
 
-  .title {
-    color: font-color(lowlight);
-    line-height: 8 * $grid-unit;
-    text-align: left;
-    padding-left: 3 * $grid-unit;
-    background-color: palette(base, 600);
-  }
   .subtitle {
     @include font-body;
     color: font-color(lowlight);

--- a/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.tsx
+++ b/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.tsx
@@ -1,13 +1,18 @@
-import { SpinnerCircular } from 'kwc';
+import { Button, BUTTON_ALIGN, SpinnerCircular } from 'kwc';
 import * as React from 'react';
 import styles from './UserKubeconfig.module.scss';
 import { useQuery } from '@apollo/client';
 import getKubeconfig from 'Graphql/queries/getKubeconfig';
 import Kubeconfig from './Components/Kubeconfig';
 import { GetKubeconfig } from 'Graphql/queries/types/GetKubeconfig';
+import { useHistory } from 'react-router-dom';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import UserPageHeader from '../../Components/UserPageHeader/UserPageHeader';
 
 function UserKubeconfig() {
   const { data, loading } = useQuery<GetKubeconfig>(getKubeconfig);
+
+  const history = useHistory();
 
   function getContent() {
     if (loading) return <SpinnerCircular />;
@@ -19,7 +24,19 @@ function UserKubeconfig() {
 
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>Kubeconfig</h1>
+      {/*<div className={styles.containerHeader}>*/}
+      {/*<Button*/}
+      {/*  Icon={ArrowBackIcon}*/}
+      {/*  onClick={goBack}*/}
+      {/*  label=""*/}
+      {/*  iconSize={'icon-regular'}*/}
+      {/*  align={BUTTON_ALIGN.MIDDLE}*/}
+      {/*  className={styles.goBackButton}*/}
+      {/*/>*/}
+      {/*  <ArrowBackIcon onClick={goBack} className={styles.goBackButton} fontSize="small" />*/}
+      {/*  <h1 className={styles.title}>Kubeconfig</h1>*/}
+      {/*</div>*/}
+      <UserPageHeader title={'Kubeconfig'} />
       <h3 className={styles.subtitle}>
         This is your private kubeconfig. You can use it to connect your local VSCode to the runtime via the Kubernetes
         extension in VSCode.

--- a/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.tsx
+++ b/app/ui/src/Pages/UserKubeconfig/UserKubeconfig.tsx
@@ -1,18 +1,14 @@
-import { Button, BUTTON_ALIGN, SpinnerCircular } from 'kwc';
+import { SpinnerCircular } from 'kwc';
 import * as React from 'react';
 import styles from './UserKubeconfig.module.scss';
 import { useQuery } from '@apollo/client';
 import getKubeconfig from 'Graphql/queries/getKubeconfig';
 import Kubeconfig from './Components/Kubeconfig';
 import { GetKubeconfig } from 'Graphql/queries/types/GetKubeconfig';
-import { useHistory } from 'react-router-dom';
-import ArrowBackIcon from '@material-ui/icons/ArrowBack';
-import UserPageHeader from '../../Components/UserPageHeader/UserPageHeader';
+import UserPageHeader from 'Components/UserPageHeader/UserPageHeader';
 
 function UserKubeconfig() {
   const { data, loading } = useQuery<GetKubeconfig>(getKubeconfig);
-
-  const history = useHistory();
 
   function getContent() {
     if (loading) return <SpinnerCircular />;
@@ -24,18 +20,6 @@ function UserKubeconfig() {
 
   return (
     <div className={styles.container}>
-      {/*<div className={styles.containerHeader}>*/}
-      {/*<Button*/}
-      {/*  Icon={ArrowBackIcon}*/}
-      {/*  onClick={goBack}*/}
-      {/*  label=""*/}
-      {/*  iconSize={'icon-regular'}*/}
-      {/*  align={BUTTON_ALIGN.MIDDLE}*/}
-      {/*  className={styles.goBackButton}*/}
-      {/*/>*/}
-      {/*  <ArrowBackIcon onClick={goBack} className={styles.goBackButton} fontSize="small" />*/}
-      {/*  <h1 className={styles.title}>Kubeconfig</h1>*/}
-      {/*</div>*/}
       <UserPageHeader title={'Kubeconfig'} />
       <h3 className={styles.subtitle}>
         This is your private kubeconfig. You can use it to connect your local VSCode to the runtime via the Kubernetes

--- a/app/ui/src/Pages/UserSshKey/UserSshKey.module.scss
+++ b/app/ui/src/Pages/UserSshKey/UserSshKey.module.scss
@@ -8,15 +8,6 @@
   padding-bottom: 10 * $grid-unit;
 }
 
-.title {
-  color: font-color(lowlight);
-  line-height: 8 * $grid-unit;
-  text-align: left;
-
-  padding-left: 3 * $grid-unit;
-  background-color: palette(base, 600);
-}
-
 .subtitle {
   @include font-body;
   color: font-color(lowlight);

--- a/app/ui/src/Pages/UserSshKey/UserSshKey.tsx
+++ b/app/ui/src/Pages/UserSshKey/UserSshKey.tsx
@@ -12,6 +12,8 @@ import useSSHKey from 'Graphql/hooks/useSSHKey';
 
 import GetSSHKeys from 'Graphql/queries/getSSHKey';
 import { runningRuntime } from '../../Graphql/client/cache';
+import { useHistory } from 'react-router-dom';
+import UserPageHeader from '../../Components/UserPageHeader/UserPageHeader';
 
 function UserSshKey() {
   const { data, loading, error } = useQuery<GetSSHKey>(GetSSHKeys);
@@ -112,7 +114,7 @@ function UserSshKey() {
 
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>SSH Key</h1>
+      <UserPageHeader title={'SSH Key'} />
       <h3 className={styles.subtitle}>
         This is your private SSH key, to grant access for your user to a project repository, copy the key and include it
         inside the SSH keys section of the repository settings page.

--- a/app/ui/src/Pages/UserSshKey/UserSshKey.tsx
+++ b/app/ui/src/Pages/UserSshKey/UserSshKey.tsx
@@ -11,9 +11,8 @@ import { useQuery, useReactiveVar } from '@apollo/client';
 import useSSHKey from 'Graphql/hooks/useSSHKey';
 
 import GetSSHKeys from 'Graphql/queries/getSSHKey';
-import { runningRuntime } from '../../Graphql/client/cache';
-import { useHistory } from 'react-router-dom';
-import UserPageHeader from '../../Components/UserPageHeader/UserPageHeader';
+import { runningRuntime } from 'Graphql/client/cache';
+import UserPageHeader from 'Components/UserPageHeader/UserPageHeader';
 
 function UserSshKey() {
   const { data, loading, error } = useQuery<GetSSHKey>(GetSSHKeys);


### PR DESCRIPTION
When navigates to kubeconfig or user ssh key pages, the left navigation bar disappears and it's annoying having to open again the project.
Since we can't keep the side bar because these routes don't belong to any project,  adding a 'go to last page' button on these pages makes it more usable. 

![image](https://user-images.githubusercontent.com/37367294/157430952-7fdba71c-0ea0-4aee-801d-0e58073262f1.png)
