### PR TITLE
fix(ci): add UI e2e tests to workflow

### DIFF
--- a/.github/workflows/kdl-server-component-build.yml
+++ b/.github/workflows/kdl-server-component-build.yml
@@ -82,6 +82,18 @@ jobs:
             ./app/ui/coverage
             ./app/ui/test-report.xml
 
+      - if: steps.changes.outputs.ui == 'true'
+        name: UI Run e2e tests
+        uses: cypress-io/github-action@v2
+        with:
+          install: true
+          working-directory: ./app/ui
+          start: npm start
+          browser: chrome
+          headless: true
+          wait-on: 'http://localhost:3001'
+          wait-on-timeout: 120
+
   build:
     needs: [ lint-dockerfile, quality-checks ]
     uses: konstellation-io/github-workflows/.github/workflows/build.yaml@v1.7.2


### PR DESCRIPTION
The UI E2E tests are not being executed on CI. This tests are more reliable than unit tests, so this change adds one step on the workflow to execute them.