### PR TITLE
[Feature]: Helm chart advanced pod scheduling

### DIFF
--- a/helm/kdl-server/templates/app/deployment.yaml
+++ b/helm/kdl-server/templates/app/deployment.yaml
@@ -147,6 +147,18 @@ spec:
             - name: project-proxy-nginx-config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+    {{- with .Values.kdlServer.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.kdlServer.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.kdlServer.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
         - name: oauth2-config
           configMap:

--- a/helm/kdl-server/templates/drone/runner-deployment.yaml
+++ b/helm/kdl-server/templates/drone/runner-deployment.yaml
@@ -35,6 +35,18 @@ spec:
         - mountPath: /etc/ssl/certs/ca-cert.pem
           name: ca-cert
           subPath: {{ .Values.tls.caSecret.certFilename }}
+    {{- with .Values.droneRunner.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.droneRunner.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.droneRunner.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: ca-cert
         secret:

--- a/helm/kdl-server/templates/drone/statefulset.yaml
+++ b/helm/kdl-server/templates/drone/statefulset.yaml
@@ -66,6 +66,18 @@ spec:
               port: 80
             initialDelaySeconds: 30
             periodSeconds: 60
+    {{- with .Values.drone.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.drone.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.drone.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: drone-pvc

--- a/helm/kdl-server/templates/gitea/statefulset.yaml
+++ b/helm/kdl-server/templates/gitea/statefulset.yaml
@@ -58,6 +58,18 @@ spec:
               port: 3000
             initialDelaySeconds: 30
             periodSeconds: 60
+    {{- with .Values.gitea.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.gitea.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.gitea.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
         - name: gitea-init
           configMap:

--- a/helm/kdl-server/templates/knowledge-galaxy/deployment.yaml
+++ b/helm/kdl-server/templates/knowledge-galaxy/deployment.yaml
@@ -32,6 +32,18 @@ spec:
               subPath: config.json
           ports:
             - containerPort: 8080
+    {{- with .Values.knowledgeGalaxy.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.knowledgeGalaxy.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.knowledgeGalaxy.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
         - name: config
           configMap:

--- a/helm/kdl-server/templates/mongo/statefulset.yaml
+++ b/helm/kdl-server/templates/mongo/statefulset.yaml
@@ -36,6 +36,18 @@ spec:
               mountPath: "/data/db"
             - name: init-scripts
               mountPath: /docker-entrypoint-initdb.d/
+    {{- with .Values.mongodb.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.mongodb.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.mongodb.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
         - name: init-scripts
           configMap:

--- a/helm/kdl-server/templates/postgres/statefulset.yaml
+++ b/helm/kdl-server/templates/postgres/statefulset.yaml
@@ -33,6 +33,18 @@ spec:
             subPath: data # to prevent warning: "initdb: directory "/var/lib/postgresql/data" exists but is not empty"
           - name: postgres-initdb
             mountPath: /docker-entrypoint-initdb.d/
+    {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.postgres.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.postgres.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
         - name: postgres-initdb
           configMap:

--- a/helm/kdl-server/templates/project-operator/deployment.yaml
+++ b/helm/kdl-server/templates/project-operator/deployment.yaml
@@ -16,6 +16,18 @@ spec:
       annotations:
         helm.sh/restart-deployment: {{ randAlphaNum 5 | quote }}
     spec:
+    {{- with .Values.projectOperator.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.projectOperator.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.projectOperator.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
       - args:
         - --secure-listen-address=0.0.0.0:8443

--- a/helm/kdl-server/templates/user-tools-operator/deployment.yaml
+++ b/helm/kdl-server/templates/user-tools-operator/deployment.yaml
@@ -31,3 +31,15 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "user-tools-operator"
+    {{- with .Values.userToolsOperator.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.userToolsOperator.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.userToolsOperator.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -114,6 +114,21 @@ gitea:
     size: 10Gi
     storageClassName: standard
 
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
 giteaOauth2Setup:
   image:
     repository: konstellation/gitea-oauth2-setup

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -343,10 +343,6 @@ mongodb:
   ##
   tolerations: []
 
-  ## This Chart feature is disabled because we have to deal with different Kubernetes API versions.
-  ## Please check the ingress template in Helm chart
-  ##
-
 oauth2Proxy:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
@@ -379,10 +375,6 @@ postgres:
   ##
   tolerations: []
 
-  ## This Chart feature is disabled because we have to deal with different Kubernetes API versions.
-  ## Please check the ingress template in Helm chart
-  ##
-
 projectOperator:
   ## Main container specs
   ##
@@ -410,6 +402,21 @@ projectOperator:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.8.0
       pullPolicy: IfNotPresent
+
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
   ## The following components are managed by the manager container when kdlproject custom resources are detected
   ##

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -363,6 +363,25 @@ postgres:
   storage:
     size: 10Gi
     storageClassName: standard
+  
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## This Chart feature is disabled because we have to deal with different Kubernetes API versions.
+  ## Please check the ingress template in Helm chart
+  ##
 
 projectOperator:
   ## Main container specs

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -476,6 +476,24 @@ userToolsOperator:
   storage:
     size: 10Gi
     storageClassName: standard
+
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## The following components are managed by the manager container when `usertool` custom resources are detected
+  ##
   jupyter:
     image:
       repository: konstellation/jupyter-gpu

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -292,6 +292,21 @@ minio:
     storageClass: standard
     existingClaim: received-data-claim
     accessMode: ReadWriteMany
+  
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
   ## This Chart feature is disabled because we have to deal with different Kubernetes API versions.
   ## Please check the ingress template in Helm chart

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -100,6 +100,21 @@ droneRunner:
     repository: drone/drone-runner-kube
     tag: 1.0.0-beta.6
     pullPolicy: IfNotPresent
+  
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
 gitea:
   admin:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -264,6 +264,21 @@ kdlServer:
     ##
     proxyBodySize: "1000000m"
 
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
 minio:
   resources:
     requests:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -328,6 +328,25 @@ mongodb:
   host: "kdl-mongo-0"
   port: 27017
 
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## This Chart feature is disabled because we have to deal with different Kubernetes API versions.
+  ## Please check the ingress template in Helm chart
+  ##
+
 oauth2Proxy:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -234,6 +234,21 @@ knowledgeGalaxy:
     ##
     imagePullSecrets: []
     # - name: regcred
+  
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
 kdlServer:
   image:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -73,6 +73,21 @@ drone:
   runnerCapacity: 5
   ingress:
     proxyBodySize: 100m
+  
+  ## Define which Nodes the Pods are scheduled on.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Assign custom affinity rules
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  affinity: {}
+
+  ## If specified, the pod's tolerations.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
 droneAuthorizer:
   image:


### PR DESCRIPTION
NodeSelector, Affinity and Toleration annotations added to the following chart components:

* drone
* droneRunner
* gitea
* knowledgeGalaxy
* kdlServer
* minio (just added default values because original MinIO chart already allows for this)
* mongodb
* postgres
* projectOperator (just for the operator pod itself) 
* userToolsOperator (just for the operator pod itself)

Closes #757 