### PR TITLE
fix(api) delete userServiceAccount on user remove

### DIFF
--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -127,7 +127,7 @@ func initUserInteractor(userInteractor user.UseCase, cfg config.Config, logger l
 		return
 	}
 
-	err = userInteractor.CreateMissingServiceAccountsForUsers()
+	err = userInteractor.SynchronizeServiceAccountsForUsers()
 	if err != nil {
 		logger.Errorf("Unexpected error creating serviceAccount for users: %s", err)
 

--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -130,10 +130,6 @@ func initUserInteractor(userInteractor user.UseCase, cfg config.Config, logger l
 	err = userInteractor.SynchronizeServiceAccountsForUsers()
 	if err != nil {
 		logger.Errorf("Unexpected error creating serviceAccount for users: %s", err)
-
-		defer os.Exit(1)
-
-		return
 	}
 }
 

--- a/app/api/infrastructure/k8s/interface.go
+++ b/app/api/infrastructure/k8s/interface.go
@@ -25,6 +25,7 @@ type Client interface {
 	GetUserSSHKeySecret(ctx context.Context, usernameSlug string) ([]byte, error)
 	GetUserSSHKeyPublic(ctx context.Context, usernameSlug string) ([]byte, error)
 	CreateUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error)
+	DeleteUserServiceAccount(ctx context.Context, usernameSlug string) error
 	GetUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error)
 	GetUserKubeconfig(ctx context.Context, usernameSlug string) ([]byte, error)
 }

--- a/app/api/infrastructure/k8s/mocks_interface.go
+++ b/app/api/infrastructure/k8s/mocks_interface.go
@@ -107,6 +107,20 @@ func (mr *MockClientMockRecorder) CreateUserToolsCR(ctx, username, runtimeID, ru
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserToolsCR", reflect.TypeOf((*MockClient)(nil).CreateUserToolsCR), ctx, username, runtimeID, runtimeImage, runtimeTag)
 }
 
+// DeleteUserServiceAccount mocks base method.
+func (m *MockClient) DeleteUserServiceAccount(ctx context.Context, usernameSlug string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserServiceAccount", ctx, usernameSlug)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUserServiceAccount indicates an expected call of DeleteUserServiceAccount.
+func (mr *MockClientMockRecorder) DeleteUserServiceAccount(ctx, usernameSlug interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserServiceAccount", reflect.TypeOf((*MockClient)(nil).DeleteUserServiceAccount), ctx, usernameSlug)
+}
+
 // DeleteUserToolsCR mocks base method.
 func (m *MockClient) DeleteUserToolsCR(ctx context.Context, username string) error {
 	m.ctrl.T.Helper()

--- a/app/api/infrastructure/k8s/service_account.go
+++ b/app/api/infrastructure/k8s/service_account.go
@@ -34,7 +34,7 @@ func (k *k8sClient) CreateUserServiceAccount(ctx context.Context, usernameSlug s
 	return serviceAccount, nil
 }
 
-// DeleteUserServiceAccount delete a serviceAccount
+// DeleteUserServiceAccount delete a serviceAccount.
 func (k *k8sClient) DeleteUserServiceAccount(ctx context.Context, usernameSlug string) error {
 	k.logger.Infof("Deleting service account for user \"%s\" in k8s...", usernameSlug)
 
@@ -46,7 +46,6 @@ func (k *k8sClient) DeleteUserServiceAccount(ctx context.Context, usernameSlug s
 	}
 
 	return nil
-
 }
 
 // GetUserServiceAccount returns the serviceAccount for the given user.

--- a/app/api/infrastructure/k8s/service_account.go
+++ b/app/api/infrastructure/k8s/service_account.go
@@ -34,6 +34,21 @@ func (k *k8sClient) CreateUserServiceAccount(ctx context.Context, usernameSlug s
 	return serviceAccount, nil
 }
 
+// DeleteUserServiceAccount delete a serviceAccount
+func (k *k8sClient) DeleteUserServiceAccount(ctx context.Context, usernameSlug string) error {
+	k.logger.Infof("Deleting service account for user \"%s\" in k8s...", usernameSlug)
+
+	saName := k.getUserServiceAccountName(usernameSlug)
+
+	err := k.clientset.CoreV1().ServiceAccounts(k.cfg.Kubernetes.Namespace).Delete(ctx, saName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
 // GetUserServiceAccount returns the serviceAccount for the given user.
 func (k *k8sClient) GetUserServiceAccount(ctx context.Context, usernameSlug string) (*v1.ServiceAccount, error) {
 	serviceAccountName := k.getUserServiceAccountName(usernameSlug)

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -326,12 +326,10 @@ func (i *interactor) SynchronizeServiceAccountsForUsers() error {
 
 	for _, user := range users {
 		if user.Deleted {
-			// Delete service account
 			if err := i.k8sClient.DeleteUserServiceAccount(ctx, user.UsernameSlug()); err != nil {
 				i.logger.Errorf("Error deleting user service account for user %s %s", user.UsernameSlug(), err)
 			}
 		} else {
-			// Create service account
 			_, err = i.k8sClient.CreateUserServiceAccount(ctx, user.UsernameSlug())
 			if err != nil && !k8errors.IsNotFound(err) {
 				i.logger.Errorf("Error creating user serviceAccount for user %s %s", user.UsernameSlug(), err)

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -3,9 +3,10 @@ package user
 import (
 	"context"
 	"errors"
-	k8errors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/gosimple/slug"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -333,7 +333,7 @@ func (i *interactor) SynchronizeServiceAccountsForUsers() error {
 			// Create service account
 			_, err = i.k8sClient.CreateUserServiceAccount(ctx, user.UsernameSlug())
 			if err != nil && !k8errors.IsNotFound(err) {
-				i.logger.Infof("Error creating user serviceAccount for user %s %s", user.UsernameSlug(), err)
+				i.logger.Errorf("Error creating user serviceAccount for user %s %s", user.UsernameSlug(), err)
 			}
 		}
 	}

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -327,7 +327,7 @@ func (i *interactor) SynchronizeServiceAccountsForUsers() error {
 		if user.Deleted {
 			// Delete service account
 			if err := i.k8sClient.DeleteUserServiceAccount(ctx, user.UsernameSlug()); err != nil {
-				i.logger.Errorf("Error deleting user service account for user %s %s", err)
+				i.logger.Errorf("Error deleting user service account for user %s %s", user.UsernameSlug(), err)
 			}
 		} else {
 			// Create service account

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -579,10 +579,9 @@ func TestInteractor_GetKubeconfig(t *testing.T) {
 	require.Equal(t, string(expectedKubeconfig), returnedKubeconfig)
 }
 
-func TestInteractor_CreateMissingServiceAccountsForUsers(t *testing.T) {
+func TestInteractor_SynchronizeServiceAccountsForUsers(t *testing.T) {
 	// GIVEN there are two active users
 	// WHEN the serviceAccounts for the users are called
-	// THEN deleted users are excluded
 	// AND k8client.CreateUserServiceAccount is called two times
 	// AND k8client.CreateUserServiceAccount is called with the usernameSlugs
 	// AND there are no errors
@@ -608,11 +607,11 @@ func TestInteractor_CreateMissingServiceAccountsForUsers(t *testing.T) {
 
 	users := []entity.User{targetUser, targetUser}
 
-	s.mocks.repo.EXPECT().FindAll(ctx, false).Return(users, nil)
+	s.mocks.repo.EXPECT().FindAll(ctx, true).Return(users, nil)
 	s.mocks.k8sClientMock.EXPECT().CreateUserServiceAccount(ctx, targetUser.UsernameSlug()).Return(nil, nil).Times(len(users))
 
 	// WHEN the CreateMissingServiceAccountsForUsers is called
-	err := s.interactor.CreateMissingServiceAccountsForUsers()
+	err := s.interactor.SynchronizeServiceAccountsForUsers()
 
 	require.NoError(t, err)
 }

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -41,5 +41,5 @@ type UseCase interface {
 	ScheduleUsersSyncJob(interval time.Duration) error
 	RunSyncUsersCronJob()
 	GetKubeconfig(ctx context.Context, username string) (string, error)
-	CreateMissingServiceAccountsForUsers() error
+	SynchronizeServiceAccountsForUsers() error
 }

--- a/app/api/usecase/user/mocks_interface.go
+++ b/app/api/usecase/user/mocks_interface.go
@@ -263,20 +263,6 @@ func (mr *MockUseCaseMockRecorder) CreateAdminUser(username, email interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAdminUser", reflect.TypeOf((*MockUseCase)(nil).CreateAdminUser), username, email)
 }
 
-// CreateMissingServiceAccountsForUsers mocks base method.
-func (m *MockUseCase) CreateMissingServiceAccountsForUsers() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMissingServiceAccountsForUsers")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateMissingServiceAccountsForUsers indicates an expected call of CreateMissingServiceAccountsForUsers.
-func (mr *MockUseCaseMockRecorder) CreateMissingServiceAccountsForUsers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMissingServiceAccountsForUsers", reflect.TypeOf((*MockUseCase)(nil).CreateMissingServiceAccountsForUsers))
-}
-
 // FindAll mocks base method.
 func (m *MockUseCase) FindAll(ctx context.Context) ([]entity.User, error) {
 	m.ctrl.T.Helper()
@@ -435,6 +421,20 @@ func (m *MockUseCase) StopTools(ctx context.Context, username string) (entity.Us
 func (mr *MockUseCaseMockRecorder) StopTools(ctx, username interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTools", reflect.TypeOf((*MockUseCase)(nil).StopTools), ctx, username)
+}
+
+// SynchronizeServiceAccountsForUsers mocks base method.
+func (m *MockUseCase) SynchronizeServiceAccountsForUsers() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SynchronizeServiceAccountsForUsers")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SynchronizeServiceAccountsForUsers indicates an expected call of SynchronizeServiceAccountsForUsers.
+func (mr *MockUseCaseMockRecorder) SynchronizeServiceAccountsForUsers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchronizeServiceAccountsForUsers", reflect.TypeOf((*MockUseCase)(nil).SynchronizeServiceAccountsForUsers))
 }
 
 // UpdateAccessLevel mocks base method.


### PR DESCRIPTION
Contemplates that, when a user is removed from the system, his userServiceAccount is deleted too on the startup synchronization.

Closes #752 