### PR TITLE
fix(api) remove a newLine char from beginning of kubeConfig text

### DIFF
--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/gosimple/slug"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
@@ -387,5 +388,8 @@ func (i *interactor) GetKubeconfig(ctx context.Context, username string) (string
 		return "", err
 	}
 
-	return string(kubeconfig), nil
+	kubeConfTxt := string(kubeconfig)
+	kubeConfTxt = strings.TrimPrefix(kubeConfTxt, "\n")
+
+	return kubeConfTxt, nil
 }


### PR DESCRIPTION
When kubeConfig text is sent to the front, the api send it with a newLine char at the beginning.

Closes #772 