### PR TITLE
fix: pass Jupyter kernels the name of the shared volume PVC from user-tools

### DIFF
--- a/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
@@ -166,6 +166,8 @@ spec:
               value: /bin/bash
             - name: KERNEL_USERNAME
               value: "{{ .Values.usernameSlug }}"
+            - name: KERNEL_SHARED_VOLUME_NAME
+              value: "{{ .Values.sharedVolume.name }}-claim"
           volumeMounts:
             - name: user-pvc
               mountPath: /home/coder


### PR DESCRIPTION
This PR modifies the user-tools-operator statefullset definition to allow the Jupyter container to pass Jupyter Kernels the name of the shared PVC via the `KERNEL_SHARED_VOLUME_NAME` environment variable.

Must be merged after #783 

Related #782 