### PR TITLE
fix: pass the right tls secret name to MinIO and user-tools ingresses

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,6 +29,6 @@ jobs:
       chart_file: helm/kdl-server/Chart.yaml
       chart_path: helm
       chart_url: http://kdl.konstellation.io
-      current_major: 2
+      current_major: 3
     secrets:
       pat: ${{ secrets.PATNAME }}

--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -916,8 +916,14 @@ spec:
                     description: size of the storage
                     type: string
               tls:
-                description: enable or disable tls
-                type: boolean
+                type: object
+                properties:
+                  enabled:
+                    description: enable or disable tls
+                    type: boolean
+                  secretName:
+                    description: the tls secret name in which the certificate is stored
+                    type: string
               username:
                 description: username to create tools
                 type: string

--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -88,3 +88,6 @@ data:
   TOOLKIT_INGRESS_TYPE: {{ .Values.ingress.type }}
   TOOLKIT_SHARED_VOLUME: {{ .Values.sharedVolume.name }}
   TOOLKIT_TLS: "{{ .Values.tls.enabled }}"
+  {{- if and .Values.tls.enabled .Values.tls.secretName }}
+  TOOLKIT_TLS_SECRET_NAME: {{ include "tlsSecretName" . }}
+  {{- end }}

--- a/helm/kdl-server/templates/minio/ingress-minio-console.yml
+++ b/helm/kdl-server/templates/minio/ingress-minio-console.yml
@@ -18,7 +18,7 @@ spec:
   tls:
     - hosts:
         - minio-console.{{ .Values.domain }}
-      secretName: {{ .Values.domain }}-tls-secret
+      secretName: {{ include "tlsSecretName" . }}
   {{- end }}
   rules:
     - host: minio-console.{{ .Values.domain }}

--- a/helm/kdl-server/templates/minio/ingress-minio.yaml
+++ b/helm/kdl-server/templates/minio/ingress-minio.yaml
@@ -18,7 +18,7 @@ spec:
   tls:
     - hosts:
         - minio.{{ .Values.domain }}
-      secretName: {{ .Values.domain }}-tls-secret
+      secretName: {{ include "tlsSecretName" . }}
   {{- end }}
   rules:
     - host: minio.{{ .Values.domain }}


### PR DESCRIPTION
This introduces the following changes:
* MinIO ingresses now use the right TLS secret name
* Introduced **TOOLKIT_TLS_SECRET_NAME** variable that passes to kdlApp the name of the TLS Secret to use in user-tools.

**WARNING:** This PR introduces a breaking change because helm/kdl-server/crds/user-tools-operator-crd.yaml has been changed and needs to be manually deployed before apply the release containing these changes.

Complements #800 and #802 