### PR TITLE
fix: pass user-tools the name of the tls secret

### DIFF
--- a/app/api/infrastructure/config/config.go
+++ b/app/api/infrastructure/config/config.go
@@ -15,8 +15,11 @@ type Config struct {
 	Port            string `yaml:"port" envconfig:"KDL_SERVER_PORT"`
 	StaticFilesPath string `yaml:"staticFilesPath" envconfig:"KDL_SERVER_STATIC_FILES_PATH"`
 	BaseDomainName  string `envconfig:"TOOLKIT_BASE_DOMAIN_NAME"`
-	TLS             bool   `envconfig:"TOOLKIT_TLS"`
-	Admin           struct {
+	TLS             struct {
+		Enabled    bool   `envconfig:"TOOLKIT_TLS"`
+		SecretName string `envconfig:"TOOLKIT_TLS_SECRET_NAME"`
+	}
+	Admin struct {
 		Username string `envconfig:"KDL_ADMIN_USERNAME"`
 		Email    string `envconfig:"KDL_ADMIN_EMAIL"`
 	}

--- a/app/api/infrastructure/k8s/kdlproject.go
+++ b/app/api/infrastructure/k8s/kdlproject.go
@@ -37,7 +37,8 @@ func (k *k8sClient) CreateKDLProjectCR(ctx context.Context, projectID string) er
 					"name": k.cfg.SharedVolume.Name,
 				},
 				"tls": map[string]interface{}{
-					"enabled": k.cfg.TLS,
+					"enabled":    k.cfg.TLS.Enabled,
+					"secretName": k.cfg.TLS.SecretName,
 				},
 				"ingress": map[string]string{
 					"type": k.cfg.VSCode.Ingress.Type,

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -156,7 +156,7 @@ func (k *k8sClient) createToolSecret(ctx context.Context, slugUsername, toolName
 	oAuthName := fmt.Sprintf("%s-app-%s", toolName, slugUsername)
 
 	protocol := "http"
-	if k.cfg.TLS {
+	if k.cfg.TLS.Enabled {
 		protocol = "https"
 	}
 
@@ -203,7 +203,10 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 				"sharedVolume": map[string]string{
 					"name": k.cfg.SharedVolume.Name,
 				},
-				"tls": k.cfg.TLS,
+				"tls": map[string]interface{}{
+					"enabled":    k.cfg.TLS.Enabled,
+					"secretName": k.cfg.TLS.SecretName,
+				},
 				"jupyter": map[string]interface{}{
 					"image": map[string]string{
 						"repository": k.cfg.Jupyter.Image.Repository,


### PR DESCRIPTION
This allows tha KDL App to pass the tls secret name to the user-tools through their UserTools resources

Complements #800 and #801