### PR TITLE
feature: pass ingress annotations from values.yaml

### DIFF
--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -897,9 +897,11 @@ spec:
               ingress:
                 type: object
                 properties:
-                  type:
-                    description: ingress type
-                    type: string
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: "Ingress annotations"
+                    type: object
               sharedVolume:
                 type: object
                 properties:

--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -84,8 +84,11 @@ data:
   USER_TOOLS_STORAGE_SIZE: {{ .Values.userToolsOperator.storage.size }}
   USER_TOOLS_STORAGE_CLASSNAME: {{ .Values.userToolsOperator.storage.storageClassName }}
 
+  # Base64 encoded string of the user-tools ingress annotations
+  USER_TOOLS_ENCODED_INGRESS_ANNOTATIONS: |+
+    {{- toYaml .Values.userToolsOperator.ingress.annotations | b64enc | nindent 4 }}
+
   TOOLKIT_BASE_DOMAIN_NAME: {{ .Values.domain }}
-  TOOLKIT_INGRESS_TYPE: {{ .Values.ingress.type }}
   TOOLKIT_SHARED_VOLUME: {{ .Values.sharedVolume.name }}
   TOOLKIT_TLS: "{{ .Values.tls.enabled }}"
   {{- if and .Values.tls.enabled .Values.tls.secretName }}

--- a/helm/kdl-server/templates/app/ingress.yaml
+++ b/helm/kdl-server/templates/app/ingress.yaml
@@ -1,23 +1,19 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{ else }}
+{{- else -}}
 apiVersion: extensions/v1beta1
-{{ end }}
+{{- end }}
 kind: Ingress
 metadata:
   name: kdl-server
+  {{- with .Values.kdlServer.ingress.annotations }}
   annotations:
-    {{ if eq .Values.ingress.type "nginx" }}
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.kdlServer.ingress.proxyBodySize }}"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.kdlServer.ingress.proxyReadTimeout }}"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.kdlServer.ingress.proxySendTimeout }}"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.kdlServer.ingress.proxyConnectTimeout }}"
-    {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{ if .Values.tls.enabled -}}
+  {{- if .Values.tls.enabled }}
   tls:
     - hosts:
         - kdlapp.{{ .Values.domain }}
@@ -27,7 +23,7 @@ spec:
     - host: kdlapp.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -35,9 +31,9 @@ spec:
                 name: kdl-server
                 port:
                   name: oauth2-proxy
-          {{ else }}
+        {{- else }}
           - path: "/"
             backend:
               serviceName: kdl-server
               servicePort: oauth2-proxy
-          {{ end }}
+        {{- end }}

--- a/helm/kdl-server/templates/app/ingress.yaml
+++ b/helm/kdl-server/templates/app/ingress.yaml
@@ -20,20 +20,20 @@ spec:
       secretName: {{ include "tlsSecretName" . }}
   {{- end }}
   rules:
-    - host: kdlapp.{{ .Values.domain }}
-      http:
-        paths:
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          - pathType: Prefix
-            path: "/"
-            backend:
-              service:
-                name: kdl-server
-                port:
-                  name: oauth2-proxy
-        {{- else }}
-          - path: "/"
-            backend:
-              serviceName: kdl-server
-              servicePort: oauth2-proxy
-        {{- end }}
+  - host: kdlapp.{{ .Values.domain }}
+    http:  
+      paths:
+        - path: "/"
+          {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+          pathType: Prefix
+          {{- end }}
+          backend:
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            service:
+              name: kdl-server
+              port:
+                number: 80
+            {{- else }}
+            serviceName: kdl-server
+            servicePort: oauth2-proxy
+            {{- end }}

--- a/helm/kdl-server/templates/drone/ingress.yaml
+++ b/helm/kdl-server/templates/drone/ingress.yaml
@@ -25,17 +25,17 @@ spec:
     - host: drone.{{ .Values.domain }}
       http:
         paths:
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          - pathType: Prefix
-            path: "/"
-            backend:
-              service:
-                name: drone
-                port:
-                  number: 80
-        {{- else }}
-          - path: /
-            backend:
-              serviceName: drone
-              servicePort: http
-        {{- end }}
+        - path: "/"
+          {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+          pathType: Prefix
+          {{- end }}
+          backend:
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            service:
+              name: drone
+              port:
+                number: 80
+            {{- else }}
+            serviceName: drone
+            servicePort: http
+            {{- end }}

--- a/helm/kdl-server/templates/drone/ingress.yaml
+++ b/helm/kdl-server/templates/drone/ingress.yaml
@@ -1,25 +1,21 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{ else }}
+{{- else -}}
 apiVersion: extensions/v1beta1
-{{ end }}
+{{- end }}
 kind: Ingress
 metadata:
   name: drone
+  {{- with .Values.drone.ingress.annotations }}
   annotations:
-    {{ if eq .Values.ingress.type "nginx" }}
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "X-Frame-Options: ALLOW-FROM {{ include "protocol" . }}://kdlapp.{{ .Values.domain }}";
-      more_set_headers "Content-Security-Policy: frame-ancestors 'self' {{ include "protocol" . }}://kdlapp.{{ .Values.domain}}";
-    {{ end }}
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.drone.ingress.proxyBodySize }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app:  drone
 spec:
-  {{ if .Values.tls.enabled -}}
+  {{- if .Values.tls.enabled }}
   tls:
     - hosts:
         - drone.{{ .Values.domain }}
@@ -29,7 +25,7 @@ spec:
     - host: drone.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -37,9 +33,9 @@ spec:
                 name: drone
                 port:
                   number: 80
-          {{ else }}
+        {{- else }}
           - path: /
             backend:
               serviceName: drone
               servicePort: http
-          {{ end }}
+        {{- end }}

--- a/helm/kdl-server/templates/gitea/ingress.yaml
+++ b/helm/kdl-server/templates/gitea/ingress.yaml
@@ -23,17 +23,17 @@ spec:
     - host: gitea.{{ .Values.domain }}
       http:
         paths:
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          - pathType: Prefix
-            path: "/"
+          - path: "/"
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: gitea
                 port:
                   number: 80
-          {{- else }}
-          - path: /
-            backend:
+              {{- else }}
               serviceName: gitea
               servicePort: http
-          {{- end }}
+              {{- end }}

--- a/helm/kdl-server/templates/gitea/ingress.yaml
+++ b/helm/kdl-server/templates/gitea/ingress.yaml
@@ -1,22 +1,19 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{ else }}
+{{- else -}}
 apiVersion: extensions/v1beta1
-{{ end }}
+{{- end }}
 kind: Ingress
 metadata:
   name: gitea
+  {{- with .Values.gitea.ingress.annotations }}
   annotations:
-    {{ if eq .Values.ingress.type "nginx" }}
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "X-Frame-Options: ALLOW-FROM {{ include "protocol" . }}://kdlapp.{{ .Values.domain }}";
-      more_set_headers "Content-Security-Policy: frame-ancestors 'self' {{ include "protocol" . }}://kdlapp.{{ .Values.domain}}";
-    {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{ if .Values.tls.enabled -}}
+  {{- if .Values.tls.enabled }}
   tls:
     - hosts:
         - gitea.{{ .Values.domain }}
@@ -26,7 +23,7 @@ spec:
     - host: gitea.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -34,10 +31,9 @@ spec:
                 name: gitea
                 port:
                   number: 80
-          {{ else }}
+          {{- else }}
           - path: /
             backend:
               serviceName: gitea
               servicePort: http
-          {{ end }}
-
+          {{- end }}

--- a/helm/kdl-server/templates/minio/ingress-minio-console.yml
+++ b/helm/kdl-server/templates/minio/ingress-minio-console.yml
@@ -23,17 +23,17 @@ spec:
     - host: minio-console.{{ .Values.domain }}
       http:
         paths:
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          - pathType: Prefix
-            path: "/"
+          - path: "/"
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ .Release.Name }}-minio-console
                 port:
                   number: 9001
-          {{- else }}
-          - path: /
-            backend:
+              {{- else }}
               serviceName: {{ .Release.Name }}-minio-console
               servicePort: 9001
-          {{- end }}
+              {{- end }}

--- a/helm/kdl-server/templates/minio/ingress-minio-console.yml
+++ b/helm/kdl-server/templates/minio/ingress-minio-console.yml
@@ -1,20 +1,19 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{ else }}
+{{- else -}}
 apiVersion: extensions/v1beta1
-{{ end }}
+{{- end }}
 kind: Ingress
 metadata:
   name: minio-console
+  {{- with .Values.minio.ingress.annotations }}
   annotations:
-    {{ if eq .Values.ingress.type "nginx" }}
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
-    {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
 spec:
-  {{ if .Values.tls.enabled -}}
+  {{- if .Values.tls.enabled }}
   tls:
     - hosts:
         - minio-console.{{ .Values.domain }}
@@ -24,7 +23,7 @@ spec:
     - host: minio-console.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -32,9 +31,9 @@ spec:
                 name: {{ .Release.Name }}-minio-console
                 port:
                   number: 9001
-          {{ else }}
+          {{- else }}
           - path: /
             backend:
               serviceName: {{ .Release.Name }}-minio-console
               servicePort: 9001
-          {{ end }}
+          {{- end }}

--- a/helm/kdl-server/templates/minio/ingress-minio.yaml
+++ b/helm/kdl-server/templates/minio/ingress-minio.yaml
@@ -23,17 +23,17 @@ spec:
     - host: minio.{{ .Values.domain }}
       http:
         paths:
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          - pathType: Prefix
-            path: "/"
+          - path: "/"
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ .Release.Name }}-minio
                 port:
                   number: 9000
-          {{- else }}
-          - path: /
-            backend:
+              {{- else }}
               serviceName: {{ .Release.Name }}-minio
               servicePort: 9000
-          {{- end }}
+              {{- end }}

--- a/helm/kdl-server/templates/minio/ingress-minio.yaml
+++ b/helm/kdl-server/templates/minio/ingress-minio.yaml
@@ -1,20 +1,19 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{ else }}
+{{- else -}}
 apiVersion: extensions/v1beta1
-{{ end }}
+{{- end }}
 kind: Ingress
 metadata:
   name: minio
+  {{- with .Values.minio.ingress.annotations }}
   annotations:
-    {{ if eq .Values.ingress.type "nginx" }}
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
-    {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
 spec:
-  {{ if .Values.tls.enabled -}}
+  {{- if .Values.tls.enabled }}
   tls:
     - hosts:
         - minio.{{ .Values.domain }}
@@ -24,7 +23,7 @@ spec:
     - host: minio.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -32,9 +31,9 @@ spec:
                 name: {{ .Release.Name }}-minio
                 port:
                   number: 9000
-          {{ else }}
+          {{- else }}
           - path: /
             backend:
               serviceName: {{ .Release.Name }}-minio
               servicePort: 9000
-          {{ end }}
+          {{- end }}

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -72,7 +72,31 @@ drone:
   adminToken: 7GSipOV0wJZQioZNBxaw3AotHV1tA4K4
   runnerCapacity: 5
   ingress:
-    proxyBodySize: 100m
+    annotations:
+      ## This Chart has been developed using Nginx Ingress Controller by default.
+      ## Using the following default annotations ensures its correct operation.
+      ## Ref: https://kubernetes.github.io/ingress-nginx/
+      ##
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/proxy-body-size: 100m
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";
+
+      ## In case of additional security to be required set the previous annotation as follows
+      ##
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
+
+      ## If additional annotations are needed to configure it, provide an additional
+      ## file ensuring they are appended to the default ones.
+      ##
+      ## Example:
+      ##
+      # kubernetes.io/ingress.class: nginx
+      # nginx.ingress.kubernetes.io/proxy-body-size: 100m
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
+      # cert-manager.io/issuer: your-issuer
 
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -128,6 +152,20 @@ gitea:
   storage:
     size: 10Gi
     storageClassName: standard
+  ingress:
+    annotations:
+      ## This Chart has been developed using Nginx Ingress Controller by default.
+      ## Using the following default annotations ensures its correct operation.
+      ## Ref: https://kubernetes.github.io/ingress-nginx/
+      ##
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";
+
+      ## In case of additional security to be required set the previous annotation as follows
+      ##
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
 
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -149,9 +187,6 @@ giteaOauth2Setup:
     repository: konstellation/gitea-oauth2-setup
     tag: v0.13.5
     pullPolicy: IfNotPresent
-
-ingress:
-  type: nginx
 
 enterprise-gateway:
   image: elyra/enterprise-gateway:2.5.0
@@ -256,13 +291,31 @@ kdlServer:
     tag: 1.15.0
     pullPolicy: IfNotPresent
   ingress:
-    proxyReadTimeout: "3600"
-    proxySendTimeout: "3600"
-    proxyConnectTimeout: "3600"
+    annotations:
+      ## This Chart has been developed using Nginx Ingress Controller by default.
+      ## Using the following default annotations ensures its correct operation.
+      ## Ref: https://kubernetes.github.io/ingress-nginx/
+      ##
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
 
-    ## Large values are needed to serve big files from Filebrowser
-    ##
-    proxyBodySize: "1000000m"
+      ## Large values are needed here to serve big files from Filebrowser
+      ##
+      nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+
+      ## If additional annotations are needed to configure it, provide an additional
+      ## file ensuring they are appended to the default ones.
+      ##
+      ## Example:
+      ##
+      # kubernetes.io/ingress.class: nginx
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      # nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
+      # nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+      # cert-manager.io/issuer: your-issuer
 
   ## Define which Nodes the Pods are scheduled on.
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -308,14 +361,12 @@ minio:
   ##
   tolerations: []
 
-  ## This Chart feature is disabled because we have to deal with different Kubernetes API versions.
-  ## Please check the ingress template in Helm chart
+  ## This Chart uses custom ingresses for MinIO and MinIO Console and not
+  ## the ones implemented by the official MinIO Chart which are disabled by default
   ##
   ingress:
-    enabled: false
-    hosts:
-      - minio.local
     annotations:
+      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
 
 mongodb:
@@ -514,6 +565,24 @@ userToolsOperator:
       repository: konstellation/kdl-py
       tag: "3.9"
       pullPolicy: IfNotPresent
+
+  ## Default ingress config for all deployed User Tools.
+  ##
+  ## This Chart has been developed using Nginx Ingress Controller by default.
+  ## Using the following default annotations ensures its correct operation.
+  ## Ref: https://kubernetes.github.io/ingress-nginx/
+  ##
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";
+
+      ## In case of additional security to be required set the previous annotation as follows
+      ##
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
 
   ## If enabled, users will be able to download a kubeconfig file, so they can attach an external terminal/IDE to
   ## the vscodeRuntime running inside KST.


### PR DESCRIPTION
This PR introduces the following changes on the helm chart:
* Remove `Values.ingress` and move it inside minio, kdlApp, drone and gitea components in values.yaml
* Move ingress annotations to their `.Values.<component>.annotations` block in values.yaml
* Add default ingress annotations for each component in values.yaml and the generated user-tools.
* Update usertools.kdl.konstellation.io CRD

BREAKING_CHANGE: values.yaml and usertools.kdl.konstellation.io have been updated

Merge before #808 