### PR TITLE
feature: pass user-tools ingress annotations through userTools k8s resources

### DIFF
--- a/app/api/infrastructure/config/config.go
+++ b/app/api/infrastructure/config/config.go
@@ -59,10 +59,7 @@ type Config struct {
 		EnterpriseGatewayURL string `envconfig:"JUPYTER_ENTERPRISE_GATEWAY_URL"`
 	}
 	VSCode struct {
-		URL     string `envconfig:"USER_TOOLS_VSCODE_URL"`
-		Ingress struct {
-			Type string `envconfig:"TOOLKIT_INGRESS_TYPE"`
-		}
+		URL   string `envconfig:"USER_TOOLS_VSCODE_URL"`
 		Image struct {
 			Repository string `envconfig:"VSCODE_IMG_REPO"`
 			Tag        string `envconfig:"VSCODE_IMG_TAG"`
@@ -148,6 +145,10 @@ type Config struct {
 			Tag        string `envconfig:"USER_TOOLS_VSCODE_RUNTIME_IMG_TAG"`
 			PullPolicy string `envconfig:"USER_TOOLS_VSCODE_RUNTIME_IMG_PULLPOLICY"`
 		}
+	}
+	UserToolsIngress struct {
+		// Base64 encoded string of the ingress annotations
+		Annotations string `envconfig:"USER_TOOLS_ENCODED_INGRESS_ANNOTATIONS"`
 	}
 }
 

--- a/app/api/infrastructure/k8s/kdlproject.go
+++ b/app/api/infrastructure/k8s/kdlproject.go
@@ -40,9 +40,6 @@ func (k *k8sClient) CreateKDLProjectCR(ctx context.Context, projectID string) er
 					"enabled":    k.cfg.TLS.Enabled,
 					"secretName": k.cfg.TLS.SecretName,
 				},
-				"ingress": map[string]string{
-					"type": k.cfg.VSCode.Ingress.Type,
-				},
 				"minio": map[string]string{
 					"accessKey": k.cfg.Minio.AccessKey,
 					"secretKey": k.cfg.Minio.SecretKey,

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -181,11 +181,14 @@ func (k *k8sClient) getIngressAnnotations() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error decoding ingress annotations: %w", err)
 	}
+
 	var ingressAnnotations map[string]interface{}
+
 	err = yaml.Unmarshal(decodedAnnotations, &ingressAnnotations)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling annotations: %w", err)
 	}
+
 	return ingressAnnotations, nil
 }
 
@@ -193,10 +196,12 @@ func (k *k8sClient) getIngressAnnotations() (map[string]interface{}, error) {
 func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, usernameSlug, resName, runtimeID,
 	runtimeImage, runtimeTag string) error {
 	serviceAccountName := k.getUserServiceAccountName(usernameSlug)
+
 	ingressAnnotations, err := k.getIngressAnnotations()
 	if err != nil {
 		return err
 	}
+
 	definition := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "UserTools",

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -2,9 +2,11 @@ package k8s
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/gosimple/slug"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -174,10 +176,27 @@ func (k *k8sClient) createToolSecret(ctx context.Context, slugUsername, toolName
 	return nil
 }
 
+func (k *k8sClient) getIngressAnnotations() (map[string]interface{}, error) {
+	decodedAnnotations, err := base64.StdEncoding.DecodeString(k.cfg.UserToolsIngress.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding ingress annotations: %w", err)
+	}
+	var ingressAnnotations map[string]interface{}
+	err = yaml.Unmarshal(decodedAnnotations, &ingressAnnotations)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling annotations: %w", err)
+	}
+	return ingressAnnotations, nil
+}
+
 // createUserToolsDefinition creates a new Custom Resource of type UserTools for the given user.
 func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, usernameSlug, resName, runtimeID,
 	runtimeImage, runtimeTag string) error {
 	serviceAccountName := k.getUserServiceAccountName(usernameSlug)
+	ingressAnnotations, err := k.getIngressAnnotations()
+	if err != nil {
+		return err
+	}
 	definition := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "UserTools",
@@ -191,8 +210,8 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 			},
 			"spec": map[string]interface{}{
 				"domain": k.cfg.BaseDomainName,
-				"ingress": map[string]string{
-					"type": k.cfg.VSCode.Ingress.Type,
+				"ingress": map[string]interface{}{
+					"annotations": ingressAnnotations,
 				},
 				"username":     username,
 				"usernameSlug": usernameSlug,
@@ -261,7 +280,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 	}
 
 	k.logger.Infof("Creating users tools: %#v", definition.Object)
-	_, err := k.userToolsRes.Namespace(k.cfg.Kubernetes.Namespace).Create(ctx, definition, metav1.CreateOptions{})
+	_, err = k.userToolsRes.Namespace(k.cfg.Kubernetes.Namespace).Create(ctx, definition, metav1.CreateOptions{})
 
 	return err
 }


### PR DESCRIPTION
This PR introduces the follwing changes:
* Allow App to pass to the generated user-tools the ingress annotations received from the chart through their `userTools` resources.

Do not merge before #806

Related #804 