### PR TITLE
feature: pass ingress annotations from values.yaml

### DIFF
--- a/user-tools-operator/helm-charts/usertools/templates/ingress.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/ingress.yaml
@@ -1,23 +1,21 @@
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{ end }}
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "user-tools.fullname" . }}
   labels:
 {{ include "user-tools.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{ if eq .Values.ingress.type "nginx" }}
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "X-Frame-Options: ALLOW-FROM {{ include "protocol" . }}://kdlapp.{{ .Values.domain }}";
-      more_set_headers "Content-Security-Policy: frame-ancestors 'self' {{ include "protocol" . }}://kdlapp.{{ .Values.domain}}";
-    {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{ if .Values.tls.enabled -}}
+  {{- if .Values.tls.enabled }}
   tls:
     - hosts:
         - {{ .Values.usernameSlug }}-code.{{ .Values.domain }}
@@ -28,7 +26,7 @@ spec:
     - host: {{ .Values.usernameSlug }}-code.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -36,16 +34,16 @@ spec:
                 name: {{ include "user-tools.fullname" . }}-code
                 port:
                   number: 80
-          {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+          {{- else }}
           - path: /
             backend:
               serviceName: {{ include "user-tools.fullname" . }}-code
               servicePort: http
-          {{ end }} 
+          {{- end }} 
     - host: {{ .Values.usernameSlug }}-jupyter.{{ .Values.domain }}
       http:
         paths:
-          {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           - pathType: Prefix
             path: "/"
             backend:
@@ -53,9 +51,9 @@ spec:
                 name: {{ include "user-tools.fullname" . }}-jupyter
                 port:
                   number: 80
-          {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+          {{- else }}
           - path: /
             backend:
               serviceName: {{ include "user-tools.fullname" . }}-jupyter
               servicePort: http
-          {{ end }} 
+          {{- end }} 

--- a/user-tools-operator/helm-charts/usertools/values.yaml
+++ b/user-tools-operator/helm-charts/usertools/values.yaml
@@ -7,7 +7,11 @@ giteaOauth2Setup:
     pullPolicy: IfNotPresent
 
 ingress:
-  type: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";
 
 jupyter:
   image:


### PR DESCRIPTION
This PR introduces the following changes
* Remove `Values.ingress.type` and add `.Values.ingress.annotations`
* Add default ingress annotations

BREAKING_CHANGE: Requires update *usertools.kdl.konstellation.io* CRD
in *kdl-server* chart to fit the changes in `values.yaml`

Merge before #806 and #807

related #804 