### PR TITLE
fix: mlflow secret in app/api/templates/basic/.drone.yml.tmpl

### DIFF
--- a/app/api/templates/basic/.drone.yml.tmpl
+++ b/app/api/templates/basic/.drone.yml.tmpl
@@ -1,7 +1,7 @@
 kind: secret
 name: minio-key-id
 get:
-  path: mlflow-server-secret
+  path: {{ .ProjectID }}-mlflow-secret
   name: AWS_ACCESS_KEY_ID
 
 ---
@@ -9,7 +9,7 @@ get:
 kind: secret
 name: minio-secret
 get:
-  path: mlflow-server-secret
+  path: {{ .ProjectID }}-mlflow-secret
   name: AWS_SECRET_ACCESS_KEY
 
 ---


### PR DESCRIPTION
This PR fixes an issue when a kdlproject is created.

The Drone `minio-key-id` and `minio-secret` now reference the kubernetes secret that is being generated by the App for the project.