### PR TITLE
fix: add `.Values.minio.consoleIngress` to pass minio-console ingress annotations

### DIFF
--- a/helm/kdl-server/templates/minio/ingress-minio-console.yml
+++ b/helm/kdl-server/templates/minio/ingress-minio-console.yml
@@ -8,7 +8,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: minio-console
-  {{- with .Values.minio.ingress.annotations }}
+  {{- with .Values.minio.consoleIngress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end}}

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -365,6 +365,11 @@ minio:
     annotations:
       kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
+  
+  consoleIngress:
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
 
 mongodb:
   auth:


### PR DESCRIPTION
This allows to pass annotations to minio-console ingress vía `.Values.minio.consoleIngress.annotations`. 

MinIO and MinIO Console ingress annotations were passed  through `.Values.minio.ingress.annotations` before and that didn't allow to pass different annotations to each ingress resource.

BREAKING_CHANGE: `.Values.minio.consoleIngress` now sets ingress annotations of MinIO Console ingress resource.