### PR TITLE
fix: user-tools-operator-crd.yaml had not status field

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,6 +29,6 @@ jobs:
       chart_file: helm/kdl-server/Chart.yaml
       chart_path: helm
       chart_url: http://kdl.konstellation.io
-      current_major: 3
+      current_major: 4
     secrets:
       pat: ${{ secrets.PATNAME }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@
 A major chart version change (like v0.15.3 -> v1.0.0) indicates that there is an incompatible breaking change needing
 manual actions.
 
+#### From 3.X to 4.X
+
+This major version comes with the following breaking changes:
+
+- Fixed an issue with **usertools.kdl.konstellation.io** CRD that produced errors in **user-tools-operator** with *UserTools* resources during the reconciling process.
+
+Run these commands to update the CRDs before applying the upgrade.
+
+```bash
+kubectl apply --server-side -f https://raw.githubusercontent.com/konstellation-io/kdl-server/v4.0.0/helm/kdl-server/crds/user-tools-operator-crd.yaml
+```
+
 #### From 2.X to 3.X
 
 This major version comes with the following breaking changes:

--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -8,7 +8,7 @@ spec:
     kind: UserTools
     listKind: UserToolsList
     plural: usertools
-    singular: usertools
+    singular: usertool
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -8,7 +8,7 @@ spec:
     kind: UserTools
     listKind: UserToolsList
     plural: usertools
-    singular: usertool
+    singular: usertools
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -17,8 +17,22 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: UserTools is the Schema for the usertools API
         properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
           spec:
+            description: Spec defines the desired state of UserTools
             type: object
             properties:
               affinity:
@@ -1040,3 +1054,9 @@ spec:
                       pullPolicy:
                         description: image pull policy
                         type: string
+          status:
+            description: Status defines the observed state of UserTools
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}


### PR DESCRIPTION
This PR adds the `status` field to the user-tools-operator-crd

Introduces a BREAKING CHANGE as **usertools.kdl.konstellation.io** CRD needs to be manually deployed