### PR TITLE
fix: oauth2-proxy named cookie not found

### DIFF
--- a/helm/kdl-server/templates/app/oauth2-proxy-configmap.yaml
+++ b/helm/kdl-server/templates/app/oauth2-proxy-configmap.yaml
@@ -12,6 +12,6 @@ data:
     profile_url="{{ printf "%s://gitea.%s/api/v1/user" ( include "protocol" . ) .Values.domain }}"
     cookie_secret="{{ randAlphaNum 16 }}"
     cookie_secure={{ ternary "true" "false" .Values.tls.enabled }}
-    cookie_samesite="none"
+    cookie_samesite="{{ ternary "none" "lax" .Values.tls.enabled }}"
     ssl_insecure_skip_verify=true
     ssl_upstream_insecure_skip_verify=true

--- a/user-tools-operator/helm-charts/usertools/templates/oauth2-proxy-configmap.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/oauth2-proxy-configmap.yaml
@@ -11,6 +11,6 @@ data:
     profile_url="{{ printf "%s://gitea.%s/api/v1/user" ( include "protocol" . ) .Values.domain }}"
     cookie_secret="p0aw4r65890a3vnl"
     cookie_secure={{ .Values.tls.enabled }}
-    cookie_samesite="none"
+    cookie_samesite="{{ ternary "none" "lax" .Values.tls.enabled }}"
     ssl_insecure_skip_verify=true
     ssl_upstream_insecure_skip_verify=true


### PR DESCRIPTION
This PR fixes the following error:

oauth2-proxy "Named cookie not found" error when TLS is disabled.

Affected components:
* user-tools-operator
* kdlApp