### PR TITLE
fix(user-tools-operator): named cookie not found error when tls is disabled

### DIFF
--- a/user-tools-operator/helm-charts/usertools/templates/oauth2-proxy-configmap.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/oauth2-proxy-configmap.yaml
@@ -11,6 +11,6 @@ data:
     profile_url="{{ printf "%s://gitea.%s/api/v1/user" ( include "protocol" . ) .Values.domain }}"
     cookie_secret="p0aw4r65890a3vnl"
     cookie_secure={{ .Values.tls.enabled }}
-    cookie_samesite="none"
+    cookie_samesite="{{ ternary "none" "lax" .Values.tls.enabled }}"
     ssl_insecure_skip_verify=true
     ssl_upstream_insecure_skip_verify=true


### PR DESCRIPTION
This PR sets the `cookie_samesite` value to "lax" in oauth2-proxy configuration when tls is disabled.
