### PR TITLE
fix: k8s resources fail to create if they contain "_" in the name

### DIFF
--- a/app/api/entity/user.go
+++ b/app/api/entity/user.go
@@ -40,5 +40,6 @@ func (u User) UsernameSlug() string {
 	slug.CustomSub = map[string]string{
 		"_": "-",
 	}
+
 	return slug.Make(u.Username)
 }

--- a/app/api/entity/user.go
+++ b/app/api/entity/user.go
@@ -37,5 +37,8 @@ type User struct {
 }
 
 func (u User) UsernameSlug() string {
+	slug.CustomSub = map[string]string{
+		"_": "-",
+	}
 	return slug.Make(u.Username)
 }

--- a/app/api/entity/user_test.go
+++ b/app/api/entity/user_test.go
@@ -1,0 +1,19 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+)
+
+func TestUsernameSlug(t *testing.T) {
+	u := &entity.User{
+		Username: "a_test",
+	}
+
+	slug := u.UsernameSlug()
+
+	if slug != "a-test" {
+		t.Errorf("The username slug does not replace invalid `_` characters")
+	}
+}


### PR DESCRIPTION
### WHY
Detailed info in #850 

### WHAT
Replace "\_" characters with "-" when generating username slugs. K8s resources that are related to users make use of the username slugs to name the resources. Avoiding "_" in the username slugs fix the resource naming problem.


closes #850 