### PR TITLE
feature: configure gitea to allow local networks IPs

### DIFF
--- a/helm/kdl-server/templates/gitea/init-configmap.yaml
+++ b/helm/kdl-server/templates/gitea/init-configmap.yaml
@@ -101,6 +101,9 @@ data:
     [cron.sync_external_users]
     SCHEDULE: @every 10m
     UPDATE_EXISTING: true
+
+    [migrations]
+    ALLOW_LOCALNETWORKS: true
   
   create-admin.sh: |+
     #!/bin/sh


### PR DESCRIPTION
### WHY

By default Gitea blocks attempts to migrate repositories from private/local networks. So when you are trying to create a project inside KDL and Gitea try to mirror a repository which resolves to a private address then it fails with `ERROR Error creating project: 422 Unprocessable Entity: {"message":"You are not allowed to import from private IPs.", "url": "http://gitea.ia.lab.***.com/api/swagger"}`

### WHAT

Configure Gitea to allow local network addresses by setting `ALLOW_LOCALNETWORKS: true` in its configuration. More info here: https://docs.gitea.io/en-us/config-cheat-sheet/#migrations-migrations


closes #854 