### PR TITLE
fix(cleaner): Update to 1.18 and add Go workspaces

### DIFF
--- a/cleaner/Dockerfile
+++ b/cleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine3.11 as builder
+FROM golang:1.18.3-alpine3.16 as builder
 
 # Build the binary statically.
 ENV CGO_ENABLED=0

--- a/cleaner/go.mod
+++ b/cleaner/go.mod
@@ -1,3 +1,3 @@
 module toolkit/cleaner
 
-go 1.14
+go 1.18


### PR DESCRIPTION
Upgrade go mod and Dockerfile to go 1.18 to make use of workspaces.

This is part of [this issue](https://github.com/konstellation-io/kdl-server/issues/848)