### PR TITLE
feat(helm): Add dynamic common labels to app configmap

### DIFF
--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -93,4 +93,7 @@ data:
   TOOLKIT_TLS: "{{ .Values.tls.enabled }}"
   {{- if and .Values.tls.enabled .Values.tls.secretName }}
   TOOLKIT_TLS_SECRET_NAME: {{ include "tlsSecretName" . }}
+
+  # Labels
+  LABELS_COMMON_RELEASE: {{ .Values.kdlServer.image.tag }}
   {{- end }}


### PR DESCRIPTION
Add common labels to the api configmap to be used when creating serviceaccounts

This is part of https://github.com/konstellation-io/kdl-server/issues/848