### PR TITLE
feat(helm): Add common labels

### DIFF
--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -97,4 +97,4 @@ data:
 
   # Labels
   LABELS_COMMON_APP_RELEASE: {{ .Values.kdlServer.image.tag }}
-  LABELS_COMMON_CHART_RELEASE: {{ .Chart.Release }}
+  LABELS_COMMON_CHART_RELEASE: {{ .Chart.Version }}

--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -94,3 +94,7 @@ data:
   {{- if and .Values.tls.enabled .Values.tls.secretName }}
   TOOLKIT_TLS_SECRET_NAME: {{ include "tlsSecretName" . }}
   {{- end }}
+
+  # Labels
+  LABELS_COMMON_APP_RELEASE: {{ .Values.kdlServer.image.tag }}
+  LABELS_COMMON_CHART_RELEASE: {{ .Chart.Release }}


### PR DESCRIPTION
Add common labels to the api configmap to be used when creating serviceaccounts

This is part of https://github.com/konstellation-io/kdl-server/issues/848