### PR TITLE
feat(app): not set 'spec.tls.secretName' on UserTools when the 'TOOLKIT_TLS_SECRET_NAME' env var is undefined

### DIFF
--- a/app/api/infrastructure/config/config.go
+++ b/app/api/infrastructure/config/config.go
@@ -16,8 +16,8 @@ type Config struct {
 	StaticFilesPath string `yaml:"staticFilesPath" envconfig:"KDL_SERVER_STATIC_FILES_PATH"`
 	BaseDomainName  string `envconfig:"TOOLKIT_BASE_DOMAIN_NAME"`
 	TLS             struct {
-		Enabled    bool   `envconfig:"TOOLKIT_TLS"`
-		SecretName string `envconfig:"TOOLKIT_TLS_SECRET_NAME"`
+		Enabled    bool    `envconfig:"TOOLKIT_TLS"`
+		SecretName *string `envconfig:"TOOLKIT_TLS_SECRET_NAME"`
 	}
 	Admin struct {
 		Username string `envconfig:"KDL_ADMIN_USERNAME"`

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -228,8 +228,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 					"name": k.cfg.SharedVolume.Name,
 				},
 				"tls": map[string]interface{}{
-					"enabled":    k.cfg.TLS.Enabled,
-					"secretName": k.cfg.TLS.SecretName,
+					"enabled": k.cfg.TLS.Enabled,
 				},
 				"jupyter": map[string]interface{}{
 					"image": map[string]string{
@@ -282,6 +281,13 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 				"serviceAccountName": serviceAccountName,
 			},
 		},
+	}
+
+	// Set spec.tls.secretName if TOOLKIT_TLS_SECRET_NAME env variable is defined
+	if k.cfg.TLS.SecretName != nil {
+		spec := definition.Object["spec"].(map[string]interface{})
+		tls := spec["tls"].(map[string]interface{})
+		tls["secretName"] = &k.cfg.TLS.SecretName
 	}
 
 	k.logger.Infof("Creating users tools: %#v", definition.Object)


### PR DESCRIPTION
This PR adds the following:
* `spec.tls.secretName` won't be defined if `TOOLKIT_TLS_SECRET_NAME` env variable is undefined.

Notice that **undefined** does not mean that the `TOOLKIT_TLS_SECRET_NAME` env variable contains the empty string value ("")