### PR TITLE
feat(user-tools-operator): autogenerate ingress tls secret name when tls.secretName is not provided from values

### DIFF
--- a/user-tools-operator/helm-charts/usertools/templates/_helpers.tpl
+++ b/user-tools-operator/helm-charts/usertools/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Add the protocol part to the uri
 {{- define "protocol" -}}
 {{ ternary "https" "http" .Values.tls.enabled }}
 {{- end -}}
+
+{{/*
+Create user-tools tls secret name
+*/}}
+{{- define "user-tools.tlsSecretName" -}}
+{{- if hasKey .Values.tls "secretName" -}}
+  {{- .Values.tls.secretName -}}
+{{- else -}}
+  {{- printf "%s-tls" (include "user-tools.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/user-tools-operator/helm-charts/usertools/templates/ingress.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - hosts:
         - {{ .Values.usernameSlug }}-code.{{ .Values.domain }}
         - {{ .Values.usernameSlug }}-jupyter.{{ .Values.domain }}
-      secretName: {{ .Values.tls.secretName }}
+      secretName: {{ include "user-tools.tlsSecretName" . }}
   {{- end }}
   rules:
     - host: {{ .Values.usernameSlug }}-code.{{ .Values.domain }}

--- a/user-tools-operator/helm-charts/usertools/values.yaml
+++ b/user-tools-operator/helm-charts/usertools/values.yaml
@@ -48,7 +48,7 @@ tls:
   ## Certificate name example:
   ##   *.example.com
   #
-  secretName: "kdl-server-tls"
+  # secretName: ""
 
 username: user.name
 


### PR DESCRIPTION
This PR adds the following:
* ingress `spec.tls.secretName` will have an autogenerated value when `tls.secretName` is not provided from values.