### PR TITLE
feat(helm): add ingressClassName to all component ingresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ helm/kdl-server/charts/
 node_modules
 backup/backup-pod.yaml
 main
+deprecations

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Changes in values:
 - `serverName` moved to `global.serverName`
 - `tls` moved to `global.ingress.tls`
 - Added `drone.ingress.tls`, `gitea.ingress.tls`, `kdlServer.ingress.tls`, `minio.ingress.tls`, `minio.consoleIngress.tls` and `userToolsOperator.ingress.tls` for individual tls config. These values take precedence over `global.ingress.tls`.
+- `drone.ingress.annotations.kubernetes.io/ingress.class: "nginx"` removed in favour of `drone.ingress.className: "nginx"`
+- `gitea.ingress.annotations.kubernetes.io/ingress.class: "nginx"` removed in favour of `gitea.ingress.className: "nginx"`
+- `kdlServer.ingress.annotations.kubernetes.io/ingress.class: "nginx"` removed in favour of `kdlServer.ingress.className: "nginx"`
+- `minio.ingress.annotations.kubernetes.io/ingress.class: "nginx"` removed in favour of `minio.ingress.className: "nginx"`
+- `minio.consoleIngress.annotations.kubernetes.io/ingress.class: "nginx"` removed in favour of `minio.consoleIngress.className: "nginx"`
+- `userToolsOperator.ingress.annotations.kubernetes.io/ingress.class: "nginx"` removed in favour of `userToolsOperator.ingress.className: "nginx"`
+
+Run these commands to update the CRDs before applying the upgrade.
+
+```bash
+kubectl apply --server-side --force-conflicts -f helm/kdl-server/crds/user-tools-operator-crd.yaml
+```
 
 #### From 3.X to 4.X
 

--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -911,6 +911,9 @@ spec:
               ingress:
                 type: object
                 properties:
+                  className:
+                    description: "The name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource."
+                    type: string
                   annotations:
                     additionalProperties:
                       type: string

--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -83,7 +83,9 @@ data:
 
   USER_TOOLS_STORAGE_SIZE: {{ .Values.userToolsOperator.storage.size }}
   USER_TOOLS_STORAGE_CLASSNAME: {{ .Values.userToolsOperator.storage.storageClassName }}
-
+  {{- if .Values.userToolsOperator.ingress.className }}
+  USER_TOOLS_INGRESS_CLASS_NAME: {{ .Values.userToolsOperator.ingress.className }}
+  {{- end }}
   # Base64 encoded string of the user-tools ingress annotations
   USER_TOOLS_ENCODED_INGRESS_ANNOTATIONS: |+
     {{- toYaml .Values.userToolsOperator.ingress.annotations | b64enc | nindent 4 }}

--- a/helm/kdl-server/templates/app/ingress.yaml
+++ b/helm/kdl-server/templates/app/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.kdlServer.ingress.className }}
+  ingressClassName: {{ .Values.kdlServer.ingress.className }}
+  {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/helm/kdl-server/templates/drone/ingress.yaml
+++ b/helm/kdl-server/templates/drone/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
   labels:
     app:  drone
 spec:
+  {{- if .Values.drone.ingress.className }}
+  ingressClassName: {{ .Values.drone.ingress.className }}
+  {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/helm/kdl-server/templates/gitea/ingress.yaml
+++ b/helm/kdl-server/templates/gitea/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.gitea.ingress.className }}
+  ingressClassName: {{ .Values.gitea.ingress.className }}
+  {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/helm/kdl-server/templates/minio/ingress-minio-console.yml
+++ b/helm/kdl-server/templates/minio/ingress-minio-console.yml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end}}
 spec:
+  {{- if .Values.minio.consoleIngress.className }}
+  ingressClassName: {{ .Values.minio.consoleIngress.className }}
+  {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/helm/kdl-server/templates/minio/ingress-minio.yaml
+++ b/helm/kdl-server/templates/minio/ingress-minio.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end}}
 spec:
+  {{- if .Values.minio.ingress.className }}
+  ingressClassName: {{ .Values.minio.ingress.className }}
+  {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -83,6 +83,7 @@ drone:
   adminToken: 7GSipOV0wJZQioZNBxaw3AotHV1tA4K4
   runnerCapacity: 5
   ingress:
+    className: "nginx"
     # -- Specify here the value for the ingress TLS `secretName` here. Example `drone.ingress.tls.secretName: "drone-tls`
     # @default -- An auto-generated secret name based on the application domain will be used
     tls: {}
@@ -91,7 +92,6 @@ drone:
       ## Using the following default annotations ensures its correct operation.
       ## Ref: https://kubernetes.github.io/ingress-nginx/
       ##
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-body-size: 100m
       nginx.ingress.kubernetes.io/configuration-snippet: |
         more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";
@@ -105,7 +105,6 @@ drone:
       ##
       ## Example:
       ##
-      # kubernetes.io/ingress.class: nginx
       # nginx.ingress.kubernetes.io/proxy-body-size: 100m
       # nginx.ingress.kubernetes.io/configuration-snippet: |
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
@@ -182,6 +181,7 @@ gitea:
     size: 10Gi
     storageClassName: standard
   ingress:
+    className: "nginx"
     # -- Specify here the value for the ingress TLS `secretName` here. Example `gitea.ingress.tls.secretName: "gitea-tls`
     # @default -- An auto-generated secret name based on the application domain will be used
     tls: {}
@@ -190,7 +190,6 @@ gitea:
       ## Using the following default annotations ensures its correct operation.
       ## Ref: https://kubernetes.github.io/ingress-nginx/
       ##
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";
       ## In case of additional security to be required set the previous annotation as follows
@@ -322,6 +321,7 @@ kdlServer:
     tag: 1.23.0
     pullPolicy: IfNotPresent
   ingress:
+    className: "nginx"
     # -- Specify here the value for the ingress TLS `secretName` here. Example `kdlServer.ingress.tls.secretName: "kdl-server-tls`
     # @default -- An auto-generated secret name based on the application domain will be used
     tls:
@@ -332,7 +332,6 @@ kdlServer:
       ## Using the following default annotations ensures its correct operation.
       ## Ref: https://kubernetes.github.io/ingress-nginx/
       ##
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
@@ -345,7 +344,6 @@ kdlServer:
       ##
       ## Example:
       ##
-      # kubernetes.io/ingress.class: nginx
       # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
       # nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
@@ -400,19 +398,19 @@ minio:
   ## the ones implemented by the official MinIO Chart which are disabled by default
   ##
   ingress:
+    className: "nginx"
     # -- Specify here the value for the ingress TLS `secretName` here. Example `minio.ingress.tls.secretName: "minio-tls`
     # @default -- An auto-generated secret name based on the application domain will be used
     tls: {}
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
 
   consoleIngress:
+    className: "nginx"
     # -- Specify here the value for the ingress TLS `secretName` here. Example `minio.consoleIngress.tls.secretName: "minio-tls`
     # @default -- An auto-generated secret name based on the application domain will be used
     tls: {}
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
 
 mongodb:
@@ -590,11 +588,11 @@ userToolsOperator:
   ## Ref: https://kubernetes.github.io/ingress-nginx/
   ##
   ingress:
+    className: "nginx"
     # -- Specify here the value for the ingress TLS `secretName` here. Example `userToolsOperator.ingress.tls.secretName: "user-tools-tls`
     # @default -- An auto-generated secret name based on the application domain will be used
     tls: {}
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         more_set_headers "Content-Security-Policy: frame-ancestors 'self' *";


### PR DESCRIPTION
This PR adds `spec.ingressClassName` field to all ingress component definitions.
 
BREAKING CHANGE: `values.yaml` and `usertools.kdl.konstellation.io` CRD have been updated
* `<component>.ingress.annotations.kubernetes.io/ingress.class: "nginx"` annotations removed in favour of `<component>.ingress.className`
* updated usertools.kdl.konstellation.io CRD