### PR TITLE
feat(app): add `spec.ingress.className` field to generated UserTools

### DIFF
--- a/app/api/infrastructure/config/config.go
+++ b/app/api/infrastructure/config/config.go
@@ -149,6 +149,7 @@ type Config struct {
 	UserToolsIngress struct {
 		// Base64 encoded string of the ingress annotations
 		Annotations string `envconfig:"USER_TOOLS_ENCODED_INGRESS_ANNOTATIONS"`
+		ClassName   string `envconfig:"USER_TOOLS_INGRESS_CLASS_NAME"`
 	}
 	Labels struct {
 		Common struct {

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -317,6 +317,7 @@ func (k *k8sClient) getUserToolsDefinition(
 		tls := spec["tls"].(map[string]interface{})
 		tls["secretName"] = &k.cfg.TLS.SecretName
 	}
+
 	return definition
 }
 

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -217,6 +217,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 				"domain": k.cfg.BaseDomainName,
 				"ingress": map[string]interface{}{
 					"annotations": ingressAnnotations,
+					"className":   k.cfg.UserToolsIngress.ClassName,
 				},
 				"username":     username,
 				"usernameSlug": usernameSlug,

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -202,6 +202,34 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 		return err
 	}
 
+	// Set spec.tls.secretName if TOOLKIT_TLS_SECRET_NAME env variable is defined
+	definition := k.getUserToolsDefinition(
+		ingressAnnotations,
+		resName,
+		username,
+		usernameSlug,
+		runtimeID,
+		runtimeImage,
+		runtimeTag,
+		serviceAccountName,
+	)
+
+	k.logger.Infof("Creating users tools: %#v", definition.Object)
+	_, err = k.userToolsRes.Namespace(k.cfg.Kubernetes.Namespace).Create(ctx, definition, metav1.CreateOptions{})
+
+	return err
+}
+
+func (k *k8sClient) getUserToolsDefinition(
+	ingressAnnotations map[string]interface{},
+	resName,
+	username,
+	usernameSlug,
+	runtimeID,
+	runtimeImage,
+	runtimeTag,
+	serviceAccountName string,
+) *unstructured.Unstructured {
 	definition := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "UserTools",
@@ -284,17 +312,12 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 		},
 	}
 
-	// Set spec.tls.secretName if TOOLKIT_TLS_SECRET_NAME env variable is defined
 	if k.cfg.TLS.SecretName != nil {
 		spec := definition.Object["spec"].(map[string]interface{})
 		tls := spec["tls"].(map[string]interface{})
 		tls["secretName"] = &k.cfg.TLS.SecretName
 	}
-
-	k.logger.Infof("Creating users tools: %#v", definition.Object)
-	_, err = k.userToolsRes.Namespace(k.cfg.Kubernetes.Namespace).Create(ctx, definition, metav1.CreateOptions{})
-
-	return err
+	return definition
 }
 
 // Returns a watcher for the UserTools.


### PR DESCRIPTION
This PR adds the posibillity of defining `spec.ingress.className` to `UserTools` generated resources.