### PR TITLE
fix(helm): manually bump projectOperator.manager.image.tag 

### DIFF
--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -87,7 +87,7 @@
 | kdlServer.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | kdlServer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | kdlServer.image.repository | string | `"konstellation/kdl-server"` | The image repository |
-| kdlServer.image.tag | string | `"1.24.0"` | The image tag |
+| kdlServer.image.tag | string | `"1.25.0"` | The image tag |
 | kdlServer.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"1000000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"3600","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"}` | Ingress annotations |
 | kdlServer.ingress.className | string | `"nginx"` | The ingress class name |
 | kdlServer.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
@@ -148,7 +148,7 @@
 | projectOperator.kubeRbacProxy.image.tag | string | `"v0.8.0"` | Image tag |
 | projectOperator.manager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | projectOperator.manager.image.repository | string | `"konstellation/project-operator"` | The image repository |
-| projectOperator.manager.image.tag | string | `"v0.13.5"` | The image tag |
+| projectOperator.manager.image.tag | string | `"0.15.0"` | The image tag |
 | projectOperator.manager.resources | object | `{}` | Resource requests and limits for primary projectOperator container. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | projectOperator.mlflow.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | projectOperator.mlflow.image.repository | string | `"konstellation/mlflow"` | The image repository |

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -138,7 +138,7 @@ drone:
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -170,7 +170,7 @@ droneRunner:
   # droneRunnerEnviron: "GIT_SSL_NO_VERIFY:true"
 
   ## Service Account to use to run in drone jobs (If you want to use IRSA or Workload Identity)
-  ## 
+  ##
   serviceAccountJob:
     # -- Whether to enable the service account for Drone job pods
     enabled: false
@@ -182,7 +182,7 @@ droneRunner:
     annotations: {}
     #  eks.amazonaws.com/role-arn: "arn:aws:iam::1234567890:role/myrole"
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -231,7 +231,7 @@ gitea:
       # nginx.ingress.kubernetes.io/configuration-snippet: |
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -315,7 +315,7 @@ knowledgeGalaxy:
     # -- The image pull policy
     pullPolicy: IfNotPresent
   config:
-    # -- Log level 
+    # -- Log level
     logLevel: "INFO"
     # -- Number of threads for the server
     workers: 1
@@ -340,7 +340,7 @@ knowledgeGalaxy:
     imagePullSecrets: []
     # - name: regcred
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -387,7 +387,7 @@ kdlServer:
       # nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -513,7 +513,7 @@ projectOperator:
       # -- The image repository
       repository: konstellation/project-operator
       # -- The image tag
-      tag: v0.13.5
+      tag: 0.15.0
       # -- The image pull policy
       pullPolicy: IfNotPresent
 
@@ -526,8 +526,8 @@ projectOperator:
     #   cpu: 100m
     #   memory: 60Mi
 
-    ## kube-rbac-proxy container specs
-    ##
+  ## kube-rbac-proxy container specs
+  ##
   kubeRbacProxy:
     image:
       # -- Image repository
@@ -577,8 +577,6 @@ projectOperator:
       tag: v2
       # -- The image pull policy
       pullPolicy: IfNotPresent
-  image:
-    tag: 0.15.0
 
 sharedVolume:
   # -- The name of the shared volume


### PR DESCRIPTION
This PR fixes the following:
* Manually bump projectOperator.manager.image.tag  to 0.15.0 because the respective workflow was not working as expected (now fixed).