### PR TITLE
fix(helm): allow project-operator to manage ingress resources

### DIFF
--- a/helm/kdl-server/templates/project-operator/rbac.yaml
+++ b/helm/kdl-server/templates/project-operator/rbac.yaml
@@ -94,6 +94,12 @@ rules:
   - deployments
   verbs:
   - '*'
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This PR fixes the following:
* project-operator had insufficient permissions for managing ingress resources when rbac is enabled in the kube-apiserver