### PR TITLE
chore(backup): use mongodb URI instead host, user and password

### DIFF
--- a/backup/files/backup-script.sh
+++ b/backup/files/backup-script.sh
@@ -22,7 +22,7 @@ function gitea_backup (){
 }
 # MongoDB backup
 function mongobackup () {
-    mongodump --host "${MONGO_HOST}" --port "${MONGO_PORT}" --username "${MONGO_INITDB_ROOT_USERNAME}" --password "${MONGO_INITDB_ROOT_PASSWORD}" --out /backup/mongodb
+    mongodump --uri="${MONGO_URI}" --out /backup/mongodb
 }
 # MLFlow backup
 function mlflow_backup (){


### PR DESCRIPTION
This PR introduces the following changes:
- use mongodb URI instead host, user and password for mongodb backup