### PR TITLE
fix(helm): manually bump user-tools-operator version 

### DIFF
--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -40,7 +40,7 @@
 | drone.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n","nginx.ingress.kubernetes.io/proxy-body-size":"100m"}` | Ingress annotations |
 | drone.ingress.className | string | `"nginx"` | The ingress class name |
 | drone.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| drone.nodeSelector | object | `{}` |  |
+| drone.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | drone.pluginSecret | string | `"d97d8ee407af1002fa2449f578bb47a9"` | Provides the secret token used to authenticate http requests to the plugin endpoint |
 | drone.rpcSecret | string | `"runner-shared-secret"` | Drone RPC secret for allowing Drone runners to authentiticate the RPC connection to the server |
 | drone.runnerCapacity | int | `5` | The max number of concurrent jobs that a Drone runner can run |
@@ -55,7 +55,7 @@
 | droneRunner.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | droneRunner.image.repository | string | `"drone/drone-runner-kube"` | The image repository |
 | droneRunner.image.tag | string | `"1.0.0-beta.6"` | The image tag |
-| droneRunner.nodeSelector | object | `{}` |  |
+| droneRunner.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | droneRunner.serviceAccountJob.annotations | object | `{}` | If `.Values.droneRunner.serviceAccountJob.create` is set to `true`, sets annotations to the service account |
 | droneRunner.serviceAccountJob.create | bool | `false` | If `.Values.droneRunner.serviceAccountJob.enabled` is set to `true`, creates the service account |
 | droneRunner.serviceAccountJob.enabled | bool | `false` | Whether to enable the service account for Drone job pods |
@@ -72,7 +72,7 @@
 | gitea.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n"}` | Ingress annotations |
 | gitea.ingress.className | string | `"nginx"` | The ingress class name |
 | gitea.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| gitea.nodeSelector | object | `{}` |  |
+| gitea.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | gitea.storage.size | string | `"10Gi"` | Storage size |
 | gitea.storage.storageClassName | string | `"standard"` | Storage class name |
 | gitea.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
@@ -94,7 +94,7 @@
 | kdlServer.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"1000000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"3600","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"}` | Ingress annotations |
 | kdlServer.ingress.className | string | `"nginx"` | The ingress class name |
 | kdlServer.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| kdlServer.nodeSelector | object | `{}` |  |
+| kdlServer.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | kdlServer.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | knowledgeGalaxy.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | knowledgeGalaxy.config.descriptionMinWords | int | `50` | Minimum number of words to use for project description |
@@ -105,7 +105,7 @@
 | knowledgeGalaxy.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | knowledgeGalaxy.image.repository | string | `"konstellation/knowledge-galaxy"` | The image repository |
 | knowledgeGalaxy.image.tag | string | `"v1.2.1"` | The image tag |
-| knowledgeGalaxy.nodeSelector | object | `{}` |  |
+| knowledgeGalaxy.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | knowledgeGalaxy.serviceaccount.annotations | object | `{}` | The service account annotations |
 | knowledgeGalaxy.serviceaccount.enabled | bool | `true` | Whether to create a service account |
 | knowledgeGalaxy.serviceaccount.imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |

--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -18,7 +18,7 @@
 | backup.extraVolumes | list | `[]` | Extra volumes for backup pods |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | backup.image.repository | string | `"konstellation/kdl-backup"` | Image repository |
-| backup.image.tag | string | `"0.21.0"` | Image tag |
+| backup.image.tag | string | `"0.22.0"` | Image tag |
 | backup.name | string | `"backup-gitea"` | Name of the backup cronjob |
 | backup.resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resource requests and limits for backup container. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | backup.s3.awsAccessKeyID | string | `"aws-access-key-id"` | AWS Access Key ID for acceding backup bucket |

--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -40,7 +40,7 @@
 | drone.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n","nginx.ingress.kubernetes.io/proxy-body-size":"100m"}` | Ingress annotations |
 | drone.ingress.className | string | `"nginx"` | The ingress class name |
 | drone.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| drone.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| drone.nodeSelector | object | `{}` |  |
 | drone.pluginSecret | string | `"d97d8ee407af1002fa2449f578bb47a9"` | Provides the secret token used to authenticate http requests to the plugin endpoint |
 | drone.rpcSecret | string | `"runner-shared-secret"` | Drone RPC secret for allowing Drone runners to authentiticate the RPC connection to the server |
 | drone.runnerCapacity | int | `5` | The max number of concurrent jobs that a Drone runner can run |
@@ -55,7 +55,7 @@
 | droneRunner.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | droneRunner.image.repository | string | `"drone/drone-runner-kube"` | The image repository |
 | droneRunner.image.tag | string | `"1.0.0-beta.6"` | The image tag |
-| droneRunner.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| droneRunner.nodeSelector | object | `{}` |  |
 | droneRunner.serviceAccountJob.annotations | object | `{}` | If `.Values.droneRunner.serviceAccountJob.create` is set to `true`, sets annotations to the service account |
 | droneRunner.serviceAccountJob.create | bool | `false` | If `.Values.droneRunner.serviceAccountJob.enabled` is set to `true`, creates the service account |
 | droneRunner.serviceAccountJob.enabled | bool | `false` | Whether to enable the service account for Drone job pods |
@@ -72,7 +72,7 @@
 | gitea.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n"}` | Ingress annotations |
 | gitea.ingress.className | string | `"nginx"` | The ingress class name |
 | gitea.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| gitea.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| gitea.nodeSelector | object | `{}` |  |
 | gitea.storage.size | string | `"10Gi"` | Storage size |
 | gitea.storage.storageClassName | string | `"standard"` | Storage class name |
 | gitea.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
@@ -90,11 +90,11 @@
 | kdlServer.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | kdlServer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | kdlServer.image.repository | string | `"konstellation/kdl-server"` | The image repository |
-| kdlServer.image.tag | string | `"1.25.0"` | The image tag |
+| kdlServer.image.tag | string | `"1.26.0"` | The image tag |
 | kdlServer.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"1000000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"3600","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"}` | Ingress annotations |
 | kdlServer.ingress.className | string | `"nginx"` | The ingress class name |
 | kdlServer.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| kdlServer.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| kdlServer.nodeSelector | object | `{}` |  |
 | kdlServer.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | knowledgeGalaxy.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | knowledgeGalaxy.config.descriptionMinWords | int | `50` | Minimum number of words to use for project description |
@@ -105,7 +105,7 @@
 | knowledgeGalaxy.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | knowledgeGalaxy.image.repository | string | `"konstellation/knowledge-galaxy"` | The image repository |
 | knowledgeGalaxy.image.tag | string | `"v1.2.1"` | The image tag |
-| knowledgeGalaxy.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| knowledgeGalaxy.nodeSelector | object | `{}` |  |
 | knowledgeGalaxy.serviceaccount.annotations | object | `{}` | The service account annotations |
 | knowledgeGalaxy.serviceaccount.enabled | bool | `true` | Whether to create a service account |
 | knowledgeGalaxy.serviceaccount.imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
@@ -160,7 +160,7 @@
 | userToolsOperator.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | userToolsOperator.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | userToolsOperator.image.repository | string | `"konstellation/user-tools-operator"` | The image repository |
-| userToolsOperator.image.tag | string | `"0.23.0"` | The image tag |
+| userToolsOperator.image.tag | string | `"0.24.0"` | The image tag |
 | userToolsOperator.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n","nginx.ingress.kubernetes.io/proxy-body-size":"1000000m"}` | Ingress annotations |
 | userToolsOperator.ingress.className | string | `"nginx"` | The ingress class name |
 | userToolsOperator.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -36,7 +36,7 @@ backup:
     # -- Image repository
     repository: konstellation/kdl-backup
     # -- Image tag
-    tag: 0.21.0
+    tag: 0.22.0
     # -- Image pull policy
     pullPolicy: IfNotPresent
 

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -574,7 +574,7 @@ userToolsOperator:
     # -- The image repository
     repository: konstellation/user-tools-operator
     # -- The image tag
-    tag: 0.23.0
+    tag: 0.24.0
     # -- The image pull policy
     pullPolicy: IfNotPresent
   storage:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -146,7 +146,7 @@ drone:
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -190,7 +190,7 @@ droneRunner:
     annotations: {}
     #  eks.amazonaws.com/role-arn: "arn:aws:iam::1234567890:role/myrole"
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -239,7 +239,7 @@ gitea:
       # nginx.ingress.kubernetes.io/configuration-snippet: |
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -348,7 +348,7 @@ knowledgeGalaxy:
     imagePullSecrets: []
     # - name: regcred
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -395,7 +395,7 @@ kdlServer:
       # nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
This PR fixes the following:
* Due an error on automatic release process the next **user-tools-operator** release was not published, so this has to be manually bumped. The new release (v0.24.0) has already been manually pushed to Dockerhub.
* Due an error on automatic release process the next **kdl-backup** release was not published, so this has to be manually bumped. The new release (v0.22.0) has already been manually pushed to Dockerhub.