### PR TITLE
chore(local-dev): fix mongodb users and roles

### DIFF
--- a/scripts/helmfile/values/kdl-local/values.yaml.gotmpl
+++ b/scripts/helmfile/values/kdl-local/values.yaml.gotmpl
@@ -10,8 +10,7 @@ global:
         certFilename: mkcert-ca.crt
   mongodb:
     connectionString:
-      # Check spec.users[0].connectionStringSecretName in scripts/helmfile/helm/default/mongodb-database/values.yaml.gotmpl
-      secretName: "mongodb-database-admin-connection-string"
+      secretName: "mongodb-database-kdl-connection-string"
       secretKey: "connectionString.standardSrv"
 
 drone:

--- a/scripts/helmfile/values/mongodb-database/values.yaml.gotmpl
+++ b/scripts/helmfile/values/mongodb-database/values.yaml.gotmpl
@@ -26,30 +26,6 @@ resources:
     security:
       authentication:
         modes: ["SCRAM"]
-      roles:
-      - role: readWriteMinusDropRole
-        db: kdl
-        privileges:
-        - resource:
-            db: kdl
-            collection: ""
-          actions:
-          - collStats
-          - dbHash
-          - dbStats
-          - find
-          - killCursors
-          - listIndexes
-          - listCollections
-          - convertToCapped
-          - createCollection
-          - createIndex
-          - dropIndex
-          - insert
-          - remove
-          - renameCollectionSameDB
-          - update
-        roles: []
     users:
     - name: admin
       db: admin
@@ -67,7 +43,7 @@ resources:
         name: {{ .Release.Name }}-kdl-password
         key: password
       roles:
-      - name: readWriteMinusDropRole
+      - name: readWrite
         db: kdl
       scramCredentialsSecretName: {{ .Release.Name }}-kdl
       connectionStringSecretName: {{ .Release.Name}}-kdl-connection-string

--- a/scripts/helmfile/values/mongodb-database/values.yaml.gotmpl
+++ b/scripts/helmfile/values/mongodb-database/values.yaml.gotmpl
@@ -5,7 +5,15 @@ resources:
     name: {{ .Release.Name }}-admin-password
   type: Opaque
   data:
-    adminPassword: {{ "123456" | b64enc | quote }}
+    password: {{ "123456" | b64enc | quote }}
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ .Release.Name }}-kdl-password
+  type: Opaque
+  data:
+    password: {{ "123456" | b64enc | quote }}
 
 - apiVersion: mongodbcommunity.mongodb.com/v1
   kind: MongoDBCommunity
@@ -47,11 +55,19 @@ resources:
       db: admin
       passwordSecretRef:
         name: {{ .Release.Name }}-admin-password
-        key: adminPassword
+        key: password
       roles:
       - name: root
         db: admin
-      - name: readWriteMinusDropRole
-        db: kdl
       scramCredentialsSecretName: {{ .Release.Name }}-admin
       connectionStringSecretName: {{ .Release.Name}}-admin-connection-string
+    - name: kdl
+      db: kdl
+      passwordSecretRef:
+        name: {{ .Release.Name }}-kdl-password
+        key: password
+      roles:
+      - name: readWriteMinusDropRole
+        db: kdl
+      scramCredentialsSecretName: {{ .Release.Name }}-kdl
+      connectionStringSecretName: {{ .Release.Name}}-kdl-connection-string


### PR DESCRIPTION
This PR fixes the way we create users and assign roles to them in the local development environment:
User list:
* **kdl** (application user):
  * database: `kdl`
  * attached roles: `readWrite` (builtin)
* **admin** (mongodb admin user):
  * database: `admin`
  * attached roles: `root` (builtin)
  
