### PR TITLE
feat(app): pass spec.minio.endpointURL to generated KDLProjects

### DIFF
--- a/app/api/infrastructure/k8s/kdlproject.go
+++ b/app/api/infrastructure/k8s/kdlproject.go
@@ -50,8 +50,9 @@ func (k *k8sClient) CreateKDLProjectCR(ctx context.Context, projectID string) er
 					"name": k.cfg.SharedVolume.Name,
 				},
 				"minio": map[string]string{
-					"accessKey": k.cfg.Minio.AccessKey,
-					"secretKey": k.cfg.Minio.SecretKey,
+					"accessKey":   k.cfg.Minio.AccessKey,
+					"secretKey":   k.cfg.Minio.SecretKey,
+					"endpointURL": k.cfg.Minio.Endpoint,
 				},
 				"giteaOauth2Setup": map[string]interface{}{
 					"image": map[string]string{

--- a/app/api/infrastructure/k8s/kdlproject.go
+++ b/app/api/infrastructure/k8s/kdlproject.go
@@ -52,7 +52,7 @@ func (k *k8sClient) CreateKDLProjectCR(ctx context.Context, projectID string) er
 				"minio": map[string]string{
 					"accessKey":   k.cfg.Minio.AccessKey,
 					"secretKey":   k.cfg.Minio.SecretKey,
-					"endpointURL": k.cfg.Minio.Endpoint,
+					"endpointURL": fmt.Sprintf("http://%s", k.cfg.Minio.Endpoint),
 				},
 				"giteaOauth2Setup": map[string]interface{}{
 					"image": map[string]string{

--- a/app/api/infrastructure/templates/templating.go
+++ b/app/api/infrastructure/templates/templating.go
@@ -86,7 +86,7 @@ func (t *templating) GenerateInitialProjectContent(ctx context.Context, project 
 	data := TemplateData{
 		ProjectID:   project.ID,
 		ProjectName: project.Name,
-		MinioURL:    t.cfg.Minio.Endpoint,
+		MinioURL:    fmt.Sprintf("http://%s", t.cfg.Minio.Endpoint),
 		MLFlowURL:   fmt.Sprintf("http://%s-mlflow:5000", project.ID),
 		SharedPVC:   fmt.Sprintf("%s-claim", t.cfg.SharedVolume.Name),
 	}

--- a/app/api/infrastructure/templates/templating.go
+++ b/app/api/infrastructure/templates/templating.go
@@ -86,7 +86,7 @@ func (t *templating) GenerateInitialProjectContent(ctx context.Context, project 
 	data := TemplateData{
 		ProjectID:   project.ID,
 		ProjectName: project.Name,
-		MinioURL:    fmt.Sprintf("http://%s", t.cfg.Minio.Endpoint),
+		MinioURL:    t.cfg.Minio.Endpoint,
 		MLFlowURL:   fmt.Sprintf("http://%s-mlflow:5000", project.ID),
 		SharedPVC:   fmt.Sprintf("%s-claim", t.cfg.SharedVolume.Name),
 	}


### PR DESCRIPTION
`spec.minio.endpointURL` is now passed to generated KDLProjects