### PR TITLE
fix(project-operator): receive MLFLOW_S3_ENDPOINT_URL from values

### DIFF
--- a/project-operator/helm-charts/kdlproject/templates/mlflow/configmap.yml
+++ b/project-operator/helm-charts/kdlproject/templates/mlflow/configmap.yml
@@ -6,3 +6,4 @@ metadata:
     app:  {{ .Values.projectId }}-mlflow-config
 data:
   ARTIFACTS_BUCKET: {{ .Values.mlflow.s3.bucket }}
+  MLFLOW_S3_ENDPOINT_URL: {{ .Values.minio.endpointURL }}

--- a/project-operator/helm-charts/kdlproject/templates/mlflow/deployment.yml
+++ b/project-operator/helm-charts/kdlproject/templates/mlflow/deployment.yml
@@ -32,12 +32,6 @@ spec:
           - 0.0.0.0
           command:
           - mlflow
-          env:
-            - name: MLFLOW_S3_ENDPOINT_URL
-              valueFrom:
-                secretKeyRef:
-                  name: tools-secret
-                  key: MINIO_URL
           envFrom:
             - configMapRef:
                 name: {{ .Values.projectId }}-mlflow-config

--- a/project-operator/helm-charts/kdlproject/templates/mlflow/secret.yml
+++ b/project-operator/helm-charts/kdlproject/templates/mlflow/secret.yml
@@ -8,3 +8,4 @@ type: Opaque
 data:
   AWS_ACCESS_KEY_ID: {{ .Values.minio.accessKey | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.secretKey | b64enc }}
+  MLFLOW_S3_ENDPOINT_URL: {{ .Values.minio.endpointURL | b64enc }}

--- a/project-operator/helm-charts/kdlproject/templates/mlflow/secret.yml
+++ b/project-operator/helm-charts/kdlproject/templates/mlflow/secret.yml
@@ -8,4 +8,3 @@ type: Opaque
 data:
   AWS_ACCESS_KEY_ID: {{ .Values.minio.accessKey | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.minio.secretKey | b64enc }}
-  MLFLOW_S3_ENDPOINT_URL: {{ .Values.minio.endpointURL | b64enc }}

--- a/project-operator/helm-charts/kdlproject/values.yaml
+++ b/project-operator/helm-charts/kdlproject/values.yaml
@@ -9,6 +9,7 @@ sharedVolume:
 minio:
   accessKey: minio
   secretKey: minio123
+  endpointURL: "http://kdl-server-minio:9000"
 
 giteaOauth2Setup:
   image:


### PR DESCRIPTION
This PR contains the following changes:
* Fix: receive `MLFLOW_S3_ENDPOINT_URL` env variable value from `values.yaml` instead of accessing to `tools-secret` kubernetes secret directly