### PR TITLE
feat(app): pass oauth2 config to generated usertools

### DIFF
--- a/app/api/.golangci.yml
+++ b/app/api/.golangci.yml
@@ -133,6 +133,9 @@ issues:
     - Potential file inclusion via variable
     # EXC0011 stylecheck: Annoying issue about not having a comment. The rare codebase has such comments
     - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
+    # EXC0012 gosec: Use of net/http's ListenAndServe function has no support for setting timeouts
+    - Use of net/http serve function that has no support for setting timeouts
+
 run:
   skip-dirs:
     - test_krt

--- a/app/api/infrastructure/config/config.go
+++ b/app/api/infrastructure/config/config.go
@@ -133,6 +133,8 @@ type Config struct {
 			Tag        string `envconfig:"USER_TOOLS_GITEA_OAUTH2_SETUP_IMG_TAG"`
 			PullPolicy string `envconfig:"USER_TOOLS_GITEA_OAUTH2_SETUP_IMG_PULLPOLICY"`
 		}
+		GiteaAdminSecret     string `envconfig:"GITEA_OAUTH2_SETUP_ADMIN_SECRETS"`
+		GiteaOauth2Configmap string `envconfig:"GITEA_OAUTH2_SETUP_CONFIGMAP"`
 	}
 	UserToolsOAuth2Proxy struct {
 		Image struct {

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -218,7 +218,6 @@ func (k *k8sClient) getUserToolsDefinition(
 	if k.cfg.UserToolsIngress.TLS.SecretName != nil {
 		tlsConfig["secretName"] = &k.cfg.UserToolsIngress.TLS.SecretName
 	}
-
 	definition := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "UserTools",

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -275,6 +275,8 @@ func (k *k8sClient) getUserToolsDefinition(
 						"tag":        k.cfg.UserToolsGiteaOAuth2Setup.Image.Tag,
 						"pullPolicy": k.cfg.UserToolsGiteaOAuth2Setup.Image.PullPolicy,
 					},
+					"giteaAdminSecret":     k.cfg.UserToolsGiteaOAuth2Setup.GiteaAdminSecret,
+					"giteaOauth2Configmap": k.cfg.UserToolsGiteaOAuth2Setup.GiteaOauth2Configmap,
 				},
 				"oauth2Proxy": map[string]interface{}{
 					"image": map[string]string{

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -203,13 +203,7 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 
 func (k *k8sClient) getUserToolsDefinition(
 	ingressAnnotations map[string]interface{},
-	resName,
-	username,
-	usernameSlug,
-	runtimeID,
-	runtimeImage,
-	runtimeTag,
-	serviceAccountName string,
+	resName, username, usernameSlug, runtimeID, runtimeImage, runtimeTag, serviceAccountName string,
 ) *unstructured.Unstructured {
 	tlsConfig := map[string]interface{}{
 		"enabled": k.cfg.TLS.Enabled,
@@ -218,6 +212,7 @@ func (k *k8sClient) getUserToolsDefinition(
 	if k.cfg.UserToolsIngress.TLS.SecretName != nil {
 		tlsConfig["secretName"] = &k.cfg.UserToolsIngress.TLS.SecretName
 	}
+
 	definition := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "UserTools",


### PR DESCRIPTION
This PR introduces the following changes:

Pass generated *UserTools* the following fields:

```yaml
spec:
  giteaOauth2Setup:
    giteaAdminSecret: <string>
    giteaOauth2Configmap: <string>
```