### PR TITLE
fix(user-tools-operator): receive oauth2 setup configmap and secrets from values

### DIFF
--- a/user-tools-operator/helm-charts/usertools/templates/ingress.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/ingress.yaml
@@ -42,7 +42,7 @@ spec:
             backend:
               serviceName: {{ include "user-tools.fullname" . }}-code
               servicePort: http
-          {{- end }} 
+          {{- end }}
     - host: {{ .Values.usernameSlug }}-jupyter.{{ .Values.domain }}
       http:
         paths:
@@ -59,4 +59,4 @@ spec:
             backend:
               serviceName: {{ include "user-tools.fullname" . }}-jupyter
               servicePort: http
-          {{- end }} 
+          {{- end }}

--- a/user-tools-operator/helm-charts/usertools/templates/rbac.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/rbac.yaml
@@ -14,14 +14,14 @@ rules:
   - ""
   resources:
   - pods/exec
-  resourceNames: 
+  resourceNames:
   - "{{ include "user-tools.fullname" . }}-0"
   verbs:
   - create
 - apiGroups:
   - ""
   resources:
-  - secrets 
+  - secrets
   verbs:
   - get
   - list

--- a/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
@@ -74,11 +74,11 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - secretRef:
-                name: gitea-admin-secrets
+                name: {{ .Values.giteaOauth2Setup.giteaAdminSecret }}
             - secretRef:
                 name: codeserver-oauth2-secrets-{{ .Values.usernameSlug }}
             - configMapRef:
-                name: gitea-configmap
+                name: {{ .Values.giteaOauth2Setup.giteaOauth2Configmap }}
         - name: jupyter-gitea-oauth2-setup
           image: {{ .Values.giteaOauth2Setup.image.repository }}:{{ .Values.giteaOauth2Setup.image.tag }}
           imagePullPolicy: {{ .Values.giteaOauth2Setup.image.pullPolicy }}
@@ -89,11 +89,11 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - secretRef:
-                name: gitea-admin-secrets
+                name: {{ .Values.giteaOauth2Setup.giteaAdminSecret }}
             - secretRef:
                 name: jupyter-oauth2-secrets-{{ .Values.usernameSlug }}
             - configMapRef:
-                name: gitea-configmap
+                name: {{ .Values.giteaOauth2Setup.giteaOauth2Configmap }}
       containers:
         - name: {{ .Chart.Name }}-repo-cloner
           image: {{ .Values.repoCloner.image.repository }}:{{ .Values.repoCloner.image.tag }}

--- a/user-tools-operator/helm-charts/usertools/values.yaml
+++ b/user-tools-operator/helm-charts/usertools/values.yaml
@@ -5,6 +5,8 @@ giteaOauth2Setup:
     repository: konstellation/gitea-oauth2-setup
     tag: "latest"
     pullPolicy: IfNotPresent
+  giteaAdminSecret: gitea-admin
+  giteaOauth2Configmap: gitea-oauth2
 
 ingress:
   className: "nginx"


### PR DESCRIPTION
This PR introduces the following changes:

* Oauth2 setup configmap and secret are now being received from values.yaml 