### PR TITLE
chore(backup): update restore-pod.yaml to fit new configmap and secret requirements

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -21,9 +21,9 @@ Also, it's important to note that MLFlow stores its data in a hostPath, so if yo
 The main files/folders used are:
 
 - `backup/Dockerfile`: the OCI image that will run the workload
-- `helm/kdl-server/templates/common/backup-cronjob.yaml`: the Cronjob manifest
+- `helm/kdl-server/templates/backup/cronjob.yaml`: the Cronjob manifest
 - `helm/kdl-server/values.yaml`: please edit this file to suit your preferences for Helm deployment.
-- `helm/kdl-server/templates/common/backup-secrets.yaml`: you will need an AWS S3 bucket and AWS key pairs to upload the backup
+- `helm/kdl-server/templates/backup/secret.yaml`: you will need an AWS S3 bucket and AWS key pairs to upload the backup
 
 ## Configurable options
 

--- a/backup/restore-pod.yaml
+++ b/backup/restore-pod.yaml
@@ -21,7 +21,7 @@ spec:
         - secretRef:
             name: postgres
         - secretRef:
-            name: backup-secrets
+            name: backup
       volumeMounts:
       - name: gitea-pvc
         mountPath: "/data"

--- a/backup/restore-pod.yaml
+++ b/backup/restore-pod.yaml
@@ -18,8 +18,6 @@ spec:
       - "-c"
       - "sleep 180m"
       envFrom:
-        - configMapRef:
-            name: gitea-config
         - secretRef:
             name: postgres
         - secretRef:


### PR DESCRIPTION
This PR introduces the following changes:

* refactor `restore-pod.yaml` to fit the new configmap and secret requirements