### PR TITLE
fix(project-operator): generate spec.tls.secretName value on mlflow

### DIFF
--- a/project-operator/helm-charts/kdlproject/templates/_helpers.tpl
+++ b/project-operator/helm-charts/kdlproject/templates/_helpers.tpl
@@ -72,9 +72,9 @@ Create the name of the service account to use
 Create project mlflow tls secret name
 */}}
 {{- define "kdlproject.mlflow.tlsSecretName" -}}
-{{- if typeIs "invalid" .Values.mlflow.ingress.tls.secretName -}}
-  {{- printf "%s-mlflow-tls" .Values.projectId -}}
-{{- else -}}
+{{- if hasKey .Values.mlflow.ingress.tls "secretName" -}}
   {{- .Values.mlflow.ingress.tls.secretName -}}
+{{- else -}}
+  {{- printf "%s-mlflow-tls" .Values.projectId -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This PR fixes the following:

Project Operator:
* Generate `spec.tls.secretName` value on mlflow ingress when `.Values.mlflow.ingress.tls.secretName` is not defined