### PR TITLE
feat(helm): add nodeSelector, affinity, and tolerations env variables for kdlproject's mlflow and filebrowser

### DIFF
--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -18,7 +18,7 @@
 | backup.extraVolumes | list | `[]` | Extra volumes for backup pods |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | backup.image.repository | string | `"konstellation/kdl-backup"` | Image repository |
-| backup.image.tag | string | `"0.22.0"` | Image tag |
+| backup.image.tag | string | `"0.23.0"` | Image tag |
 | backup.name | string | `"backup-gitea"` | Name of the backup cronjob |
 | backup.resources | object | `{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Resource requests and limits for backup container. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | backup.s3.awsAccessKeyID | string | `"aws-access-key-id"` | AWS Access Key ID for acceding backup bucket |
@@ -80,7 +80,7 @@
 | gitea.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | giteaOauth2Setup.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | giteaOauth2Setup.image.repository | string | `"konstellation/gitea-oauth2-setup"` | The image repository |
-| giteaOauth2Setup.image.tag | string | `"0.15.0"` | The image tag |
+| giteaOauth2Setup.image.tag | string | `"0.16.0"` | The image tag |
 | global.domain | string | `"kdl.local"` | The DNS domain name that will serve the application |
 | global.ingress.tls.caSecret | object | `{}` | A secret containing the the CA cert is needed in order to use a self-signed certificate. Check [values.yaml](./values.yaml) for usage details. |
 | global.ingress.tls.enabled | bool | `true` | Whether to enable TLS |
@@ -91,7 +91,7 @@
 | kdlServer.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | kdlServer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | kdlServer.image.repository | string | `"konstellation/kdl-server"` | The image repository |
-| kdlServer.image.tag | string | `"1.27.0"` | The image tag |
+| kdlServer.image.tag | string | `"1.28.0"` | The image tag |
 | kdlServer.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"1000000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"3600","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"}` | Ingress annotations |
 | kdlServer.ingress.className | string | `"nginx"` | The ingress class name |
 | kdlServer.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
@@ -136,22 +136,28 @@
 | postgres.storage.storageClassName | string | `"standard"` | Storage class to use for persistence |
 | postgres.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | projectOperator.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| projectOperator.filebrowser.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | projectOperator.filebrowser.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | projectOperator.filebrowser.image.repository | string | `"filebrowser/filebrowser"` | The image repository |
 | projectOperator.filebrowser.image.tag | string | `"v2"` | The image tag |
+| projectOperator.filebrowser.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| projectOperator.filebrowser.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | projectOperator.kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | projectOperator.kubeRbacProxy.image.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | Image repository |
 | projectOperator.kubeRbacProxy.image.tag | string | `"v0.8.0"` | Image tag |
 | projectOperator.manager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | projectOperator.manager.image.repository | string | `"konstellation/project-operator"` | The image repository |
-| projectOperator.manager.image.tag | string | `"0.16.0"` | The image tag |
+| projectOperator.manager.image.tag | string | `"0.18.0"` | The image tag |
 | projectOperator.manager.resources | object | `{}` | Resource requests and limits for primary projectOperator container. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
+| projectOperator.mlflow.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | projectOperator.mlflow.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | projectOperator.mlflow.image.repository | string | `"konstellation/mlflow"` | The image repository |
 | projectOperator.mlflow.image.tag | string | `"v0.13.5"` | The image tag |
 | projectOperator.mlflow.ingress.annotations | object | `{}` | Ingress annotations |
 | projectOperator.mlflow.ingress.className | string | `"nginx"` | The ingress class name |
 | projectOperator.mlflow.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
+| projectOperator.mlflow.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| projectOperator.mlflow.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | projectOperator.mlflow.volume.size | string | `"1Gi"` | The storage size for the persistent volume claim |
 | projectOperator.mlflow.volume.storageClassName | string | `"standard"` | Storage class to use for persistence |
 | projectOperator.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -162,7 +168,7 @@
 | userToolsOperator.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | userToolsOperator.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | userToolsOperator.image.repository | string | `"konstellation/user-tools-operator"` | The image repository |
-| userToolsOperator.image.tag | string | `"0.25.0"` | The image tag |
+| userToolsOperator.image.tag | string | `"0.26.0"` | The image tag |
 | userToolsOperator.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n","nginx.ingress.kubernetes.io/proxy-body-size":"1000000m"}` | Ingress annotations |
 | userToolsOperator.ingress.className | string | `"nginx"` | The ingress class name |
 | userToolsOperator.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |

--- a/helm/kdl-server/crds/project-operator-crd.yaml
+++ b/helm/kdl-server/crds/project-operator-crd.yaml
@@ -38,6 +38,891 @@ spec:
               domain:
                 description: domain name
                 type: string
+              filebrowser:
+                type: object
+                properties:
+                  affinity:
+                    description: If specified, the pod's scheduling constraints.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to
+                              nodes that satisfy the affinity expressions specified by
+                              this field, but it may choose a node that violates one or
+                              more of the expressions. The node that is most preferred
+                              is the one with the greatest sum of weights, i.e. for each
+                              node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements of
+                              this field and adding "weight" to the sum if the node matches
+                              the corresponding matchExpressions; the node(s) with the
+                              highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects (i.e.
+                                is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the
+                                    corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to an update), the system may or may not try to
+                              eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to
+                              nodes that satisfy the affinity expressions specified by
+                              this field, but it may choose a node that violates one or
+                              more of the expressions. The node that is most preferred
+                              is the one with the greatest sum of weights, i.e. for each
+                              node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements of
+                              this field and adding "weight" to the sum if the node has
+                              pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by this
+                                        field and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list
+                                        means "this pod's namespace". An empty selector
+                                        ({}) matches all namespaces. This field is beta-level
+                                        and is only honored when PodAffinityNamespaceSelector
+                                        feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to. The
+                                        term is applied to the union of the namespaces
+                                        listed in this field and the ones selected by
+                                        namespaceSelector. null or empty namespaces list
+                                        and null namespaceSelector means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey
+                                        matches that of any node on which any of the selected
+                                        pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to a pod label update), the system may or may
+                              not try to eventually evict the pod from its node. When
+                              there are multiple elements, the lists of nodes corresponding
+                              to each podAffinityTerm are intersected, i.e. all terms
+                              must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of
+                                pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied to the
+                                    union of the namespaces selected by this field and
+                                    the ones listed in the namespaces field. null selector
+                                    and null or empty namespaces list means "this pod's
+                                    namespace". An empty selector ({}) matches all namespaces.
+                                    This field is beta-level and is only honored when
+                                    PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace
+                                    names that the term applies to. The term is applied
+                                    to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector. null or
+                                    empty namespaces list and null namespaceSelector means
+                                    "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of
+                                    any node on which any of the selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to
+                              nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates one
+                              or more of the expressions. The node that is most preferred
+                              is the one with the greatest sum of weights, i.e. for each
+                              node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions,
+                              etc.), compute a sum by iterating through the elements of
+                              this field and adding "weight" to the sum if the node has
+                              pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by this
+                                        field and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list
+                                        means "this pod's namespace". An empty selector
+                                        ({}) matches all namespaces. This field is beta-level
+                                        and is only honored when PodAffinityNamespaceSelector
+                                        feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to. The
+                                        term is applied to the union of the namespaces
+                                        listed in this field and the ones selected by
+                                        namespaceSelector. null or empty namespaces list
+                                        and null namespaceSelector means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey
+                                        matches that of any node on which any of the selected
+                                        pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the anti-affinity requirements
+                              specified by this field cease to be met at some point during
+                              pod execution (e.g. due to a pod label update), the system
+                              may or may not try to eventually evict the pod from its
+                              node. When there are multiple elements, the lists of nodes
+                              corresponding to each podAffinityTerm are intersected, i.e.
+                              all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of
+                                pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied to the
+                                    union of the namespaces selected by this field and
+                                    the ones listed in the namespaces field. null selector
+                                    and null or empty namespaces list means "this pod's
+                                    namespace". An empty selector ({}) matches all namespaces.
+                                    This field is beta-level and is only honored when
+                                    PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace
+                                    names that the term applies to. The term is applied
+                                    to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector. null or
+                                    empty namespaces list and null namespaceSelector means
+                                    "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of
+                                    any node on which any of the selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Define which Nodes the Pods are scheduled on.
+                    type: object
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any
+                        taint that matches the triple <key,value,effect> using the matching
+                        operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match all
+                            values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod
+                            can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default, it
+                            is not set, which means tolerate the taint forever (do not
+                            evict). Zero and negative values will be treated as 0 (evict
+                            immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  image:
+                    type: object
+                    properties:
+                      repository:
+                        description: image repository
+                        type: string
+                      tag:
+                        description: image tag
+                        type: string
+                      pullPolicy:
+                        description: image pull policy
+                        type: string
               giteaOauth2Setup:
                 type: object
                 properties:
@@ -68,6 +953,876 @@ spec:
               mlflow:
                 type: object
                 properties:
+                  affinity:
+                    description: If specified, the pod's scheduling constraints.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to
+                              nodes that satisfy the affinity expressions specified by
+                              this field, but it may choose a node that violates one or
+                              more of the expressions. The node that is most preferred
+                              is the one with the greatest sum of weights, i.e. for each
+                              node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements of
+                              this field and adding "weight" to the sum if the node matches
+                              the corresponding matchExpressions; the node(s) with the
+                              highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects (i.e.
+                                is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the
+                                    corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to an update), the system may or may not try to
+                              eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If
+                                              the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values array
+                                              must be empty. If the operator is Gt or
+                                              Lt, the values array must have a single
+                                              element, which will be interpreted as an
+                                              integer. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to
+                              nodes that satisfy the affinity expressions specified by
+                              this field, but it may choose a node that violates one or
+                              more of the expressions. The node that is most preferred
+                              is the one with the greatest sum of weights, i.e. for each
+                              node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements of
+                              this field and adding "weight" to the sum if the node has
+                              pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by this
+                                        field and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list
+                                        means "this pod's namespace". An empty selector
+                                        ({}) matches all namespaces. This field is beta-level
+                                        and is only honored when PodAffinityNamespaceSelector
+                                        feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to. The
+                                        term is applied to the union of the namespaces
+                                        listed in this field and the ones selected by
+                                        namespaceSelector. null or empty namespaces list
+                                        and null namespaceSelector means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey
+                                        matches that of any node on which any of the selected
+                                        pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to a pod label update), the system may or may
+                              not try to eventually evict the pod from its node. When
+                              there are multiple elements, the lists of nodes corresponding
+                              to each podAffinityTerm are intersected, i.e. all terms
+                              must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of
+                                pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied to the
+                                    union of the namespaces selected by this field and
+                                    the ones listed in the namespaces field. null selector
+                                    and null or empty namespaces list means "this pod's
+                                    namespace". An empty selector ({}) matches all namespaces.
+                                    This field is beta-level and is only honored when
+                                    PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace
+                                    names that the term applies to. The term is applied
+                                    to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector. null or
+                                    empty namespaces list and null namespaceSelector means
+                                    "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of
+                                    any node on which any of the selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to
+                              nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates one
+                              or more of the expressions. The node that is most preferred
+                              is the one with the greatest sum of weights, i.e. for each
+                              node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions,
+                              etc.), compute a sum by iterating through the elements of
+                              this field and adding "weight" to the sum if the node has
+                              pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by this
+                                        field and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list
+                                        means "this pod's namespace". An empty selector
+                                        ({}) matches all namespaces. This field is beta-level
+                                        and is only honored when PodAffinityNamespaceSelector
+                                        feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a key,
+                                              and an operator that relates the key and
+                                              values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to. The
+                                        term is applied to the union of the namespaces
+                                        listed in this field and the ones selected by
+                                        namespaceSelector. null or empty namespaces list
+                                        and null namespaceSelector means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey
+                                        matches that of any node on which any of the selected
+                                        pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the anti-affinity requirements
+                              specified by this field cease to be met at some point during
+                              pod execution (e.g. due to a pod label update), the system
+                              may or may not try to eventually evict the pod from its
+                              node. When there are multiple elements, the lists of nodes
+                              corresponding to each podAffinityTerm are intersected, i.e.
+                              all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of
+                                pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied to the
+                                    union of the namespaces selected by this field and
+                                    the ones listed in the namespaces field. null selector
+                                    and null or empty namespaces list means "this pod's
+                                    namespace". An empty selector ({}) matches all namespaces.
+                                    This field is beta-level and is only honored when
+                                    PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a
+                                          selector that contains values, a key, and an
+                                          operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist, the
+                                              values array must be empty. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value". The
+                                        requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace
+                                    names that the term applies to. The term is applied
+                                    to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector. null or
+                                    empty namespaces list and null namespaceSelector means
+                                    "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of
+                                    any node on which any of the selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Define which Nodes the Pods are scheduled on.
+                    type: object
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any
+                        taint that matches the triple <key,value,effect> using the matching
+                        operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match all
+                            values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod
+                            can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default, it
+                            is not set, which means tolerate the taint forever (do not
+                            evict). Zero and negative values will be treated as 0 (evict
+                            immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   image:
                     type: object
                     properties:

--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -47,10 +47,22 @@ data:
   {{- if and .Values.global.ingress.tls.enabled (or (not (kindIs "invalid" .Values.projectOperator.mlflow.ingress.tls.secretName )) (not (kindIs "invalid" .Values.global.ingress.tls.secretName ))) }}
   PROJECT_MLFLOW_INGRESS_TLS_SECRET_NAME: "{{ include "projectOperator.mlflow.tlsSecretName" . }}"
   {{- end }}
+  PROJECT_MLFLOW_NODESELECTOR: |+
+    {{- toYaml .Values.projectOperator.mlflow.nodeSelector | b64enc | nindent 4 }}
+  ROJECT_MLFLOW_AFFINITY: |+
+    {{- toYaml .Values.projectOperator.mlflow.affinity | b64enc | nindent 4 }}
+  ROJECT_MLFLOW_TOLERATIONS: |+
+    {{- toYaml .Values.projectOperator.mlflow.tolerations | b64enc | nindent 4 }}
 
   PROJECT_FILEBROWSER_IMG_REPO: "{{ .Values.projectOperator.filebrowser.image.repository }}"
   PROJECT_FILEBROWSER_IMG_TAG: "{{ .Values.projectOperator.filebrowser.image.tag }}"
   PROJECT_FILEBROWSER_IMG_PULLPOLICY: "{{ .Values.projectOperator.filebrowser.image.pullPolicy }}"
+  PROJECT_FILEBROWSER_NODESELECTOR: |+
+    {{- toYaml .Values.projectOperator.filebrowser.nodeSelector | b64enc | nindent 4 }}
+  PROJECT_FILEBROWSER_AFFINITY: |+
+    {{- toYaml .Values.projectOperator.filebrowser.affinity | b64enc | nindent 4 }}
+  PROJECT_FILEBROWSER_TOLERATIONS: |+
+    {{- toYaml .Values.projectOperator.filebrowser.tolerations | b64enc | nindent 4 }}
 
   VSCODE_IMG_REPO: "{{ .Values.userToolsOperator.vscode.image.repository }}"
   VSCODE_IMG_TAG: "{{ .Values.userToolsOperator.vscode.image.tag }}"

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -142,7 +142,7 @@ drone:
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -194,7 +194,7 @@ droneRunner:
     annotations: {}
     #  eks.amazonaws.com/role-arn: "arn:aws:iam::1234567890:role/myrole"
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -243,7 +243,7 @@ gitea:
       # nginx.ingress.kubernetes.io/configuration-snippet: |
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -352,7 +352,7 @@ knowledgeGalaxy:
     imagePullSecrets: []
     # - name: regcred
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -399,7 +399,7 @@ kdlServer:
       # nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -559,6 +559,16 @@ projectOperator:
       className: "nginx"
       # -- Ingress annotations
       annotations: {}
+
+    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+    nodeSelector: {}
+
+    # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    affinity: {}
+
+    # -- If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
   filebrowser:
     image:
       # -- The image repository
@@ -567,6 +577,15 @@ projectOperator:
       tag: v2
       # -- The image pull policy
       pullPolicy: IfNotPresent
+
+    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+    nodeSelector: {}
+
+    # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    affinity: {}
+
+    # -- If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
 
 sharedVolume:
   # -- The name of the shared volume


### PR DESCRIPTION
**WHY**

kdl-server app needs to retrieve pod scheduling options from char's values

**WHAT**

Added environment variables to `kdl-server` configmap in order to pass kdl-app the kdlproject's pods scheduling strategies.

BREAKING CHANGE: kdlprojects.project.konstellation.io CRD has been updated