### PR TITLE
feat(capabilities): Add capabilites selector to the UI, and the needed backend services

### DIFF
--- a/.github/workflows/kdl-server-component-build.yml
+++ b/.github/workflows/kdl-server-component-build.yml
@@ -94,6 +94,8 @@ jobs:
           browser: chrome
           wait-on: 'http://localhost:3001'
           wait-on-timeout: 120
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
 
   build:
     needs: [ lint-dockerfile, quality-checks ]

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .run/*.xml
 .certs
 .vscode/
+.trunk/
 coverage/
 helm/kdl-server/charts/
 node_modules

--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -5,9 +5,9 @@ type Capabilities struct {
 	ID            string            `bson:"_id"`
 	Name          string            `bson:"name"`
 	Default       bool              `bson:"default"`
-	NodeSelectors map[string]string `bson:"node_selectors"` // TODO validate schema matches this
-	Affinities    []string          `bson:"affinities"`     // TODO replace with struct
-	Taints        []string          `bson:"taints"`         // TODO replace with struct
+	NodeSelectors map[string]string `bson:"node_selectors"`
+	Affinities    []string          `bson:"affinities"`
+	Taints        []string          `bson:"taints"`
 }
 
 func (c Capabilities) GetNodeSelectors() map[string]string {
@@ -15,14 +15,12 @@ func (c Capabilities) GetNodeSelectors() map[string]string {
 }
 
 func (c Capabilities) GetAffinities() map[string]interface{} {
-	//TODO model affinities object
 	return map[string]interface{}{
 		"affinity": map[string]interface{}{},
 	}
 }
 
 func (c Capabilities) GetTaints() map[string]interface{} {
-	// TODO model tains object
 	return map[string]interface{}{
 		"taints": map[string]interface{}{},
 	}

--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -1,0 +1,33 @@
+package entity
+
+// Capabilities entity definition.
+type Capabilities struct {
+	ID            string
+	Name          string
+	NodeSelectors []map[string]string
+	Affinities    []string
+	Taints        []string
+}
+
+func MockCapabilities() Capabilities {
+	return Capabilities{
+		ID:   "mock",
+		Name: "mock",
+		NodeSelectors: []map[string]string{
+			{"selector1": "test1"},
+			{"selector2": "test2"},
+		},
+		Affinities: []string{"affinities1", "affinities2"},
+		Taints:     []string{"taints1", "taints2"},
+	}
+}
+
+func (c Capabilities) GetNodeSelectors() []map[string]string {
+	return c.NodeSelectors
+}
+
+func (c Capabilities) GetAffinities() map[string]interface{} {
+	return map[string]interface{}{
+		"affinity": map[string]interface{}{},
+	}
+}

--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -2,27 +2,27 @@ package entity
 
 // Capabilities entity definition.
 type Capabilities struct {
-	ID            string              `bson:"_id"`
-	Name          string              `bson:"name"`
-	NodeSelectors []map[string]string `bson:"node_selectors"` // TODO validate schema matches this
-	Affinities    []string            `bson:"affinities"`     // TODO replace with struct
-	Taints        []string            `bson:"taints"`         // TODO replace with struct
+	ID            string            `bson:"_id"`
+	Name          string            `bson:"name"`
+	NodeSelectors map[string]string `bson:"node_selectors"` // TODO validate schema matches this
+	Affinities    []string          `bson:"affinities"`     // TODO replace with struct
+	Taints        []string          `bson:"taints"`         // TODO replace with struct
 }
 
 func MockCapabilities() Capabilities { // TODO remove when the repository is implemented
 	return Capabilities{
 		ID:   "mockCapabilitiesID",
 		Name: "mock",
-		NodeSelectors: []map[string]string{
-			{"selector1": "test1"},
-			{"selector2": "test2"},
+		NodeSelectors: map[string]string{
+			"selector1": "test1",
+			"selector2": "test2",
 		},
 		Affinities: []string{"affinities1", "affinities2"},
 		Taints:     []string{"taints1", "taints2"},
 	}
 }
 
-func (c Capabilities) GetNodeSelectors() []map[string]string {
+func (c Capabilities) GetNodeSelectors() map[string]string {
 	return c.NodeSelectors
 }
 

--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -4,22 +4,10 @@ package entity
 type Capabilities struct {
 	ID            string            `bson:"_id"`
 	Name          string            `bson:"name"`
+	Default       bool              `bson:"default"`
 	NodeSelectors map[string]string `bson:"node_selectors"` // TODO validate schema matches this
 	Affinities    []string          `bson:"affinities"`     // TODO replace with struct
 	Taints        []string          `bson:"taints"`         // TODO replace with struct
-}
-
-func MockCapabilities() Capabilities { // TODO remove when the repository is implemented
-	return Capabilities{
-		ID:   "mockCapabilitiesID",
-		Name: "mock",
-		NodeSelectors: map[string]string{
-			"selector1": "test1",
-			"selector2": "test2",
-		},
-		Affinities: []string{"affinities1", "affinities2"},
-		Taints:     []string{"taints1", "taints2"},
-	}
 }
 
 func (c Capabilities) GetNodeSelectors() map[string]string {
@@ -27,7 +15,15 @@ func (c Capabilities) GetNodeSelectors() map[string]string {
 }
 
 func (c Capabilities) GetAffinities() map[string]interface{} {
+	//TODO model affinities object
 	return map[string]interface{}{
 		"affinity": map[string]interface{}{},
+	}
+}
+
+func (c Capabilities) GetTaints() map[string]interface{} {
+	// TODO model tains object
+	return map[string]interface{}{
+		"taints": map[string]interface{}{},
 	}
 }

--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -2,16 +2,16 @@ package entity
 
 // Capabilities entity definition.
 type Capabilities struct {
-	ID            string
-	Name          string
-	NodeSelectors []map[string]string
-	Affinities    []string
-	Taints        []string
+	ID            string              `bson:"_id"`
+	Name          string              `bson:"name"`
+	NodeSelectors []map[string]string `bson:"node_selectors"` // TODO validate schema matches this
+	Affinities    []string            `bson:"affinities"`     // TODO replace with struct
+	Taints        []string            `bson:"taints"`         // TODO replace with struct
 }
 
-func MockCapabilities() Capabilities {
+func MockCapabilities() Capabilities { // TODO remove when the repository is implemented
 	return Capabilities{
-		ID:   "mock",
+		ID:   "mockCapabilitiesID",
 		Name: "mock",
 		NodeSelectors: []map[string]string{
 			{"selector1": "test1"},

--- a/app/api/entity/capabilities_test.go
+++ b/app/api/entity/capabilities_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestCapabilitiesNodeSelector(t *testing.T) {
 	cap := &entity.Capabilities{
-		ID:   "test_id",
-		Name: "Test capability",
+		ID:      "test_id",
+		Name:    "Test capability",
 		Default: false,
 		NodeSelectors: map[string]string{
 			"test1": "value1",

--- a/app/api/entity/capabilities_test.go
+++ b/app/api/entity/capabilities_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCapabilitiesNodeSelector(t *testing.T) {
-	cap := &entity.Capabilities{
+	capability := &entity.Capabilities{
 		ID:      "test_id",
 		Name:    "Test capability",
 		Default: false,
@@ -19,7 +19,7 @@ func TestCapabilitiesNodeSelector(t *testing.T) {
 		Taints:     []string{},
 	}
 
-	nodeSelectors := cap.GetNodeSelectors()
+	nodeSelectors := capability.GetNodeSelectors()
 
 	if !reflect.DeepEqual(nodeSelectors, map[string]string{"test1": "value1"}) {
 		t.Errorf("The NodeSelector has not the expected values")

--- a/app/api/entity/capabilities_test.go
+++ b/app/api/entity/capabilities_test.go
@@ -1,0 +1,27 @@
+package entity_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+)
+
+func TestCapabilitiesNodeSelector(t *testing.T) {
+	cap := &entity.Capabilities{
+		ID:   "test_id",
+		Name: "Test capability",
+		Default: false,
+		NodeSelectors: map[string]string{
+			"test1": "value1",
+		},
+		Affinities: []string{},
+		Taints:     []string{},
+	}
+
+	nodeSelectors := cap.GetNodeSelectors()
+
+	if !reflect.DeepEqual(nodeSelectors, map[string]string{"test1": "value1"}) {
+		t.Errorf("The NodeSelector has not the expected values")
+	}
+}

--- a/app/api/entity/error.go
+++ b/app/api/entity/error.go
@@ -26,4 +26,7 @@ var (
 
 	// ErrNoRunningRuntime error definition.
 	ErrNoRunningRuntime = fmt.Errorf("no running runtime")
+
+	// ErrCapabilitiesNotFound error definition.
+	ErrCapabilitiesNotFound = errors.New("capabilities not found")
 )

--- a/app/api/go.mod
+++ b/app/api/go.mod
@@ -27,10 +27,59 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/aws/aws-sdk-go v1.34.28 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/googleapis/gnostic v0.1.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/hashicorp/go-version v1.2.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
+	github.com/klauspost/compress v1.9.5 // indirect
+	github.com/klauspost/cpuid v1.3.1 // indirect
+	github.com/minio/md5-simd v1.1.0 // indirect
+	github.com/minio/sha256-simd v0.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.3.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
+	github.com/rs/xid v1.2.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/appengine v1.5.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.57.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
+	sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/app/api/go.mod
+++ b/app/api/go.mod
@@ -27,59 +27,10 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f // indirect
-	github.com/acomagu/bufpipe v1.0.3 // indirect
-	github.com/agnivade/levenshtein v1.1.1 // indirect
-	github.com/aws/aws-sdk-go v1.34.28 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/golang/snappy v0.0.1 // indirect
-	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.1.1 // indirect
-	github.com/googleapis/gnostic v0.1.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
-	github.com/hashicorp/go-version v1.2.1 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
-	github.com/klauspost/compress v1.9.5 // indirect
-	github.com/klauspost/cpuid v1.3.1 // indirect
-	github.com/minio/md5-simd v1.1.0 // indirect
-	github.com/minio/sha256-simd v0.1.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.3.1 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
-	github.com/rs/xid v1.2.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
-	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
-	github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/appengine v1.5.0 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/ini.v1 v1.57.0 // indirect
-	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/klog v1.0.0 // indirect
-	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 // indirect
-	sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/app/api/go.sum
+++ b/app/api/go.sum
@@ -61,7 +61,6 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -344,7 +343,6 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -393,7 +391,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/app/api/go.sum
+++ b/app/api/go.sum
@@ -61,6 +61,7 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -343,6 +344,7 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -391,6 +393,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/konstellation-io/kdl-server/app/api/pkg/logging"
 	"github.com/konstellation-io/kdl-server/app/api/pkg/mongodb"
 	"github.com/konstellation-io/kdl-server/app/api/pkg/sshhelper"
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/project"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/user"
@@ -98,12 +99,15 @@ func main() {
 
 	runtimeInteractor := runtime.NewInteractor(logger, k8sClient, runtimeRepo)
 
+	capabilitiesInteractor := capabilities.NewInteractor(logger, cfg, capabilitiesRepo, k8sClient)
+
 	resolvers := graph.NewResolver(
 		logger,
 		cfg,
 		projectInteractor,
 		userInteractor,
 		runtimeInteractor,
+		capabilitiesInteractor,
 	)
 
 	startHTTPServer(logger, cfg.Port, cfg.StaticFilesPath, cfg.Kubernetes.IsInsideCluster, resolvers, userRepo, projectRepo)

--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -71,6 +71,7 @@ func main() {
 	projectRepo := repository.NewProjectMongoDBRepo(logger, mongodbClient, cfg.MongoDB.DBName)
 	userRepo := repository.NewUserMongoDBRepo(logger, mongodbClient, cfg.MongoDB.DBName)
 	runtimeRepo := repository.NewRuntimeMongoDBRepo(logger, mongodbClient, cfg.MongoDB.DBName)
+	capabilitiesRepo := repository.NewCapabilitiesMongoDBRepo(logger, mongodbClient, cfg.MongoDB.DBName)
 
 	tmpl := templates.NewTemplating(cfg, logger, k8sClient)
 
@@ -79,7 +80,7 @@ func main() {
 		logger.Errorf("Error creating indexes for users: %s", err)
 	}
 
-	userInteractor := user.NewInteractor(logger, cfg, userRepo, runtimeRepo, sshHelper, realClock, giteaService, k8sClient)
+	userInteractor := user.NewInteractor(logger, cfg, userRepo, runtimeRepo, capabilitiesRepo, sshHelper, realClock, giteaService, k8sClient)
 	initUserInteractor(userInteractor, cfg, logger)
 
 	projectDeps := &project.InteractorDeps{

--- a/app/api/http/middleware/auth.go
+++ b/app/api/http/middleware/auth.go
@@ -12,25 +12,26 @@ const (
 	LoggedUserEmailKey
 )
 
-/**
-	AuthMiddleware gets the logged user from the incoming HTTP headers.
-	It sets into the context the username and the email of the logged user.
-	The oAuth2 proxy sets the following headers:
+/*
+AuthMiddleware gets the logged user from the incoming HTTP headers.
+It sets into the context the username and the email of the logged user.
+The oAuth2 proxy sets the following headers:
 
-		X-Forwarded-Email: test@test.com
-		X-Forwarded-For: 192.168.99.1, 172.17.0.4
-		X-Forwarded-Host: kdlapp.kdl.192.168.99.135.nip.io
-		X-Forwarded-User: toolkit-admin
-		X-Request-Id: 4b0965af799c37bb1c26da5844a3308f
-		X-Scheme: https
-		X-Real-Ip: 192.168.99.1
-		X-Forwarded-Proto: https
-		X-Forwarded-Port: 443
+	X-Forwarded-Email: test@test.com
+	X-Forwarded-For: 192.168.99.1, 172.17.0.4
+	X-Forwarded-Host: kdlapp.kdl.192.168.99.135.nip.io
+	X-Forwarded-User: toolkit-admin
+	X-Request-Id: 4b0965af799c37bb1c26da5844a3308f
+	X-Scheme: https
+	X-Real-Ip: 192.168.99.1
+	X-Forwarded-Proto: https
+	X-Forwarded-Port: 443
 
-	Use LoggedUserNameKey and LoggedUserEmailKey to retrieve this values from the context.
-	Example:
-		email := ctx.Value(middleware.LoggedUserEmailKey).(string)
-**/
+Use LoggedUserNameKey and LoggedUserEmailKey to retrieve this values from the context.
+Example:
+
+	email := ctx.Value(middleware.LoggedUserEmailKey).(string).
+*/
 func AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		email := r.Header.Get("X-Forwarded-Email")

--- a/app/api/http/middleware/auth.go
+++ b/app/api/http/middleware/auth.go
@@ -12,25 +12,25 @@ const (
 	LoggedUserEmailKey
 )
 
-/*
-AuthMiddleware gets the logged user from the incoming HTTP headers.
-It sets into the context the username and the email of the logged user.
-The oAuth2 proxy sets the following headers:
+/**
+	AuthMiddleware gets the logged user from the incoming HTTP headers.
+	It sets into the context the username and the email of the logged user.
+	The oAuth2 proxy sets the following headers:
 
-	X-Forwarded-Email: test@test.com
-	X-Forwarded-For: 192.168.99.1, 172.17.0.4
-	X-Forwarded-Host: kdlapp.kdl.192.168.99.135.nip.io
-	X-Forwarded-User: toolkit-admin
-	X-Request-Id: 4b0965af799c37bb1c26da5844a3308f
-	X-Scheme: https
-	X-Real-Ip: 192.168.99.1
-	X-Forwarded-Proto: https
-	X-Forwarded-Port: 443
+		X-Forwarded-Email: test@test.com
+		X-Forwarded-For: 192.168.99.1, 172.17.0.4
+		X-Forwarded-Host: kdlapp.kdl.192.168.99.135.nip.io
+		X-Forwarded-User: toolkit-admin
+		X-Request-Id: 4b0965af799c37bb1c26da5844a3308f
+		X-Scheme: https
+		X-Real-Ip: 192.168.99.1
+		X-Forwarded-Proto: https
+		X-Forwarded-Port: 443
 
-Use LoggedUserNameKey and LoggedUserEmailKey to retrieve this values from the context.
-Example:
-	email := ctx.Value(middleware.LoggedUserEmailKey).(string)
-*/
+	Use LoggedUserNameKey and LoggedUserEmailKey to retrieve this values from the context.
+	Example:
+		email := ctx.Value(middleware.LoggedUserEmailKey).(string)
+**/
 func AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		email := r.Header.Get("X-Forwarded-Email")

--- a/app/api/infrastructure/graph/generated/generated.go
+++ b/app/api/infrastructure/graph/generated/generated.go
@@ -58,6 +58,12 @@ type ComplexityRoot struct {
 		Token        func(childComplexity int) int
 	}
 
+	Capability struct {
+		Default func(childComplexity int) int
+		ID      func(childComplexity int) int
+		Name    func(childComplexity int) int
+	}
+
 	Member struct {
 		AccessLevel func(childComplexity int) int
 		AddedDate   func(childComplexity int) int
@@ -99,11 +105,13 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
+		Capabilities       func(childComplexity int) int
 		Kubeconfig         func(childComplexity int) int
 		Me                 func(childComplexity int) int
 		Project            func(childComplexity int, id string) int
 		Projects           func(childComplexity int) int
 		QualityProjectDesc func(childComplexity int, description string) int
+		RunningCapability  func(childComplexity int) int
 		RunningRuntime     func(childComplexity int) int
 		Runtimes           func(childComplexity int) int
 		Users              func(childComplexity int) int
@@ -197,6 +205,8 @@ type QueryResolver interface {
 	QualityProjectDesc(ctx context.Context, description string) (*model.QualityProjectDesc, error)
 	Runtimes(ctx context.Context) ([]entity.Runtime, error)
 	RunningRuntime(ctx context.Context) (*entity.Runtime, error)
+	Capabilities(ctx context.Context) ([]model.Capability, error)
+	RunningCapability(ctx context.Context) (*model.Capability, error)
 	Kubeconfig(ctx context.Context) (string, error)
 }
 type RepositoryResolver interface {
@@ -263,6 +273,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ApiToken.Token(childComplexity), true
+
+	case "Capability.default":
+		if e.complexity.Capability.Default == nil {
+			break
+		}
+
+		return e.complexity.Capability.Default(childComplexity), true
+
+	case "Capability.id":
+		if e.complexity.Capability.ID == nil {
+			break
+		}
+
+		return e.complexity.Capability.ID(childComplexity), true
+
+	case "Capability.name":
+		if e.complexity.Capability.Name == nil {
+			break
+		}
+
+		return e.complexity.Capability.Name(childComplexity), true
 
 	case "Member.accessLevel":
 		if e.complexity.Member.AccessLevel == nil {
@@ -510,6 +541,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.QualityProjectDesc.Quality(childComplexity), true
 
+	case "Query.capabilities":
+		if e.complexity.Query.Capabilities == nil {
+			break
+		}
+
+		return e.complexity.Query.Capabilities(childComplexity), true
+
 	case "Query.kubeconfig":
 		if e.complexity.Query.Kubeconfig == nil {
 			break
@@ -554,6 +592,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.QualityProjectDesc(childComplexity, args["description"].(string)), true
+
+	case "Query.runningCapability":
+		if e.complexity.Query.RunningCapability == nil {
+			break
+		}
+
+		return e.complexity.Query.RunningCapability(childComplexity), true
 
 	case "Query.runningRuntime":
 		if e.complexity.Query.RunningRuntime == nil {
@@ -897,6 +942,8 @@ var sources = []*ast.Source{
   qualityProjectDesc(description: String!): QualityProjectDesc!
   runtimes: [Runtime!]!
   runningRuntime: Runtime
+  capabilities: [Capability!]!
+  runningCapability: Capability
   kubeconfig: String!
 }
 
@@ -927,6 +974,12 @@ type Runtime {
   dockerImage: String!
   dockerTag: String!
   runtimePod: String!
+}
+
+type Capability {
+  id: ID!
+  name: String!
+  default: Boolean!
 }
 
 type Topic {
@@ -1046,6 +1099,7 @@ input SetBoolFieldInput {
 input SetActiveUserToolsInput {
   active: Boolean!,
   runtimeId: String,
+  capabilitiesId: String
 }
 
 type Project {
@@ -1550,6 +1604,138 @@ func (ec *executionContext) fieldContext_ApiToken_token(ctx context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Capability_id(ctx context.Context, field graphql.CollectedField, obj *model.Capability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Capability_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Capability_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Capability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Capability_name(ctx context.Context, field graphql.CollectedField, obj *model.Capability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Capability_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Capability_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Capability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Capability_default(ctx context.Context, field graphql.CollectedField, obj *model.Capability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Capability_default(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Default, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Capability_default(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Capability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3628,6 +3814,107 @@ func (ec *executionContext) fieldContext_Query_runningRuntime(ctx context.Contex
 				return ec.fieldContext_Runtime_runtimePod(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Runtime", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_capabilities(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_capabilities(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Capabilities(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]model.Capability)
+	fc.Result = res
+	return ec.marshalNCapability2ᚕgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCapabilityᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_capabilities(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Capability_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Capability_name(ctx, field)
+			case "default":
+				return ec.fieldContext_Capability_default(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Capability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_runningCapability(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_runningCapability(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().RunningCapability(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Capability)
+	fc.Result = res
+	return ec.marshalOCapability2ᚖgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCapability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_runningCapability(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Capability_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Capability_name(ctx, field)
+			case "default":
+				return ec.fieldContext_Capability_default(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Capability", field.Name)
 		},
 	}
 	return fc, nil
@@ -7377,6 +7664,14 @@ func (ec *executionContext) unmarshalInputSetActiveUserToolsInput(ctx context.Co
 			if err != nil {
 				return it, err
 			}
+		case "capabilitiesId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("capabilitiesId"))
+			it.CapabilitiesID, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -7580,6 +7875,48 @@ func (ec *executionContext) _ApiToken(ctx context.Context, sel ast.SelectionSet,
 		case "token":
 
 			out.Values[i] = ec._ApiToken_token(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var capabilityImplementors = []string{"Capability"}
+
+func (ec *executionContext) _Capability(ctx context.Context, sel ast.SelectionSet, obj *model.Capability) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, capabilityImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Capability")
+		case "id":
+
+			out.Values[i] = ec._Capability_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+
+			out.Values[i] = ec._Capability_name(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "default":
+
+			out.Values[i] = ec._Capability_default(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -8131,6 +8468,49 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_runningRuntime(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "capabilities":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_capabilities(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "runningCapability":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_runningCapability(ctx, field)
 				return res
 			}
 
@@ -9043,6 +9423,54 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) marshalNCapability2githubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCapability(ctx context.Context, sel ast.SelectionSet, v model.Capability) graphql.Marshaler {
+	return ec._Capability(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCapability2ᚕgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCapabilityᚄ(ctx context.Context, sel ast.SelectionSet, v []model.Capability) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCapability2githubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCapability(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNCreateProjectInput2githubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCreateProjectInput(ctx context.Context, v interface{}) (model.CreateProjectInput, error) {
 	res, err := ec.unmarshalInputCreateProjectInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -9757,6 +10185,13 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	}
 	res := graphql.MarshalBoolean(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOCapability2ᚖgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐCapability(ctx context.Context, sel ast.SelectionSet, v *model.Capability) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Capability(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOExternalRepositoryInput2ᚖgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐExternalRepositoryInput(ctx context.Context, v interface{}) (*model.ExternalRepositoryInput, error) {

--- a/app/api/infrastructure/graph/model/models_gen.go
+++ b/app/api/infrastructure/graph/model/models_gen.go
@@ -23,6 +23,12 @@ type APITokenInput struct {
 	Name   *string `json:"name"`
 }
 
+type Capability struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Default bool   `json:"default"`
+}
+
 type CreateProjectInput struct {
 	ID          string           `json:"id"`
 	Name        string           `json:"name"`
@@ -60,8 +66,9 @@ type RepositoryInput struct {
 }
 
 type SetActiveUserToolsInput struct {
-	Active    bool    `json:"active"`
-	RuntimeID *string `json:"runtimeId"`
+	Active         bool    `json:"active"`
+	RuntimeID      *string `json:"runtimeId"`
+	CapabilitiesID *string `json:"capabilitiesId"`
 }
 
 type SetBoolFieldInput struct {

--- a/app/api/infrastructure/graph/resolver.go
+++ b/app/api/infrastructure/graph/resolver.go
@@ -1,5 +1,7 @@
 package graph
 
+//go:generate go run github.com/99designs/gqlgen generate
+
 import (
 	"context"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/konstellation-io/kdl-server/app/api/entity"
 	"github.com/konstellation-io/kdl-server/app/api/http/middleware"
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/project"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/user"
@@ -20,11 +23,12 @@ import (
 
 // Resolver serves as dependency injection for the app, add any dependencies app require here.
 type Resolver struct {
-	logger   logging.Logger
-	cfg      config.Config
-	projects project.UseCase
-	users    user.UseCase
-	runtimes runtime.UseCase
+	logger       logging.Logger
+	cfg          config.Config
+	projects     project.UseCase
+	users        user.UseCase
+	runtimes     runtime.UseCase
+	capabilities capabilities.UseCase
 }
 
 // NewResolver is a constructor function.
@@ -34,13 +38,15 @@ func NewResolver(
 	projectInteractor project.UseCase,
 	userInteractor user.UseCase,
 	runtimeInteractor runtime.UseCase,
+	capabilitiesInteractor capabilities.UseCase,
 ) *Resolver {
 	return &Resolver{
-		logger:   logger,
-		cfg:      cfg,
-		projects: projectInteractor,
-		users:    userInteractor,
-		runtimes: runtimeInteractor,
+		logger:       logger,
+		cfg:          cfg,
+		projects:     projectInteractor,
+		users:        userInteractor,
+		runtimes:     runtimeInteractor,
+		capabilities: capabilitiesInteractor,
 	}
 }
 

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -164,12 +164,17 @@ func (r *mutationResolver) SetActiveUserTools(ctx context.Context, input model.S
 	username := ctx.Value(middleware.LoggedUserNameKey).(string)
 
 	if input.Active {
-		u, err := r.users.StartTools(ctx, username, input.RuntimeID)
+		u, err := r.users.StartTools(ctx, username, input.RuntimeID, input.CapabilitiesID)
+		if err != nil {
+			r.logger.Errorf("Error on StartTools: %w", err)
+		}
 		return &u, err
 	}
 
 	u, err := r.users.StopTools(ctx, username)
-
+	if err != nil {
+		r.logger.Errorf("Error on StartTools: %w", err)
+	}
 	return &u, err
 }
 
@@ -269,6 +274,15 @@ func (r *queryResolver) Runtimes(ctx context.Context) ([]entity.Runtime, error) 
 func (r *queryResolver) RunningRuntime(ctx context.Context) (*entity.Runtime, error) {
 	runtime, err := r.runtimes.GetRunningRuntime(ctx, ctx.Value(middleware.LoggedUserNameKey).(string))
 	return runtime, err
+}
+
+func (r *queryResolver) Capabilities(ctx context.Context) ([]model.Capability, error) {
+	return r.capabilities.GetCapabilities(ctx)
+}
+
+func (r *queryResolver) RunningCapability(ctx context.Context) (*model.Capability, error) {
+	capabilities, err := r.capabilities.GetRunningCapability(ctx, ctx.Value(middleware.LoggedUserNameKey).(string))
+	return capabilities, err
 }
 
 func (r *queryResolver) Kubeconfig(ctx context.Context) (string, error) {

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -169,6 +169,7 @@ func (r *mutationResolver) SetActiveUserTools(ctx context.Context, input model.S
 	}
 
 	u, err := r.users.StopTools(ctx, username)
+
 	return &u, err
 }
 

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -165,16 +165,10 @@ func (r *mutationResolver) SetActiveUserTools(ctx context.Context, input model.S
 
 	if input.Active {
 		u, err := r.users.StartTools(ctx, username, input.RuntimeID, input.CapabilitiesID)
-		if err != nil {
-			r.logger.Errorf("Error on StartTools: %w", err)
-		}
 		return &u, err
 	}
 
 	u, err := r.users.StopTools(ctx, username)
-	if err != nil {
-		r.logger.Errorf("Error on StartTools: %w", err)
-	}
 	return &u, err
 }
 

--- a/app/api/infrastructure/k8s/interface.go
+++ b/app/api/infrastructure/k8s/interface.go
@@ -19,6 +19,7 @@ type Client interface {
 	DeleteUserToolsCR(ctx context.Context, username string) error
 	IsUserToolPODRunning(ctx context.Context, username string) (bool, error)
 	GetRuntimeIDFromUserTools(ctx context.Context, username string) (string, error)
+	GetCapabilitiesIDFromUserTools(ctx context.Context, username string) (string, error)
 	CreateKDLProjectCR(ctx context.Context, projectID string) error
 	CreateUserSSHKeySecret(ctx context.Context, user entity.User, public, private string) error
 	UpdateUserSSHKeySecret(ctx context.Context, user entity.User, public, private string) error

--- a/app/api/infrastructure/k8s/interface.go
+++ b/app/api/infrastructure/k8s/interface.go
@@ -15,7 +15,7 @@ type Client interface {
 	CreateSecret(ctx context.Context, name string, values map[string]string) error
 	UpdateSecret(ctx context.Context, name string, values map[string]string) error
 	GetSecret(ctx context.Context, name string) (map[string][]byte, error)
-	CreateUserToolsCR(ctx context.Context, username, runtimeID, runtimeImage, runtimeTag string) error
+	CreateUserToolsCR(ctx context.Context, username, runtimeID, runtimeImage, runtimeTag string, capabilities entity.Capabilities) error
 	DeleteUserToolsCR(ctx context.Context, username string) error
 	IsUserToolPODRunning(ctx context.Context, username string) (bool, error)
 	GetRuntimeIDFromUserTools(ctx context.Context, username string) (string, error)

--- a/app/api/infrastructure/k8s/mocks_interface.go
+++ b/app/api/infrastructure/k8s/mocks_interface.go
@@ -150,6 +150,19 @@ func (mr *MockClientMockRecorder) GetRuntimeIDFromUserTools(ctx, username interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRuntimeIDFromUserTools", reflect.TypeOf((*MockClient)(nil).GetRuntimeIDFromUserTools), ctx, username)
 }
 
+func (m *MockClient) GetCapabilitiesIDFromUserTools(ctx context.Context, username string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCapabilitiesIDFromUserTools", ctx, username)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockClientMockRecorder) GetCapabilitiesIDFromUserTools(ctx context.Context, username interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapabilitiesIDFromUserTools", reflect.TypeOf((*MockClient)(nil).GetCapabilitiesIDFromUserTools), ctx, username)
+}
+
 // GetSecret mocks base method.
 func (m *MockClient) GetSecret(ctx context.Context, name string) (map[string][]byte, error) {
 	m.ctrl.T.Helper()

--- a/app/api/infrastructure/k8s/mocks_interface.go
+++ b/app/api/infrastructure/k8s/mocks_interface.go
@@ -94,17 +94,17 @@ func (mr *MockClientMockRecorder) CreateUserServiceAccount(ctx, usernameSlug int
 }
 
 // CreateUserToolsCR mocks base method.
-func (m *MockClient) CreateUserToolsCR(ctx context.Context, username, runtimeID, runtimeImage, runtimeTag string) error {
+func (m *MockClient) CreateUserToolsCR(ctx context.Context, username, runtimeID, runtimeImage, runtimeTag string, capabilities entity.Capabilities) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUserToolsCR", ctx, username, runtimeID, runtimeImage, runtimeTag)
+	ret := m.ctrl.Call(m, "CreateUserToolsCR", ctx, username, runtimeID, runtimeImage, runtimeTag, capabilities)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateUserToolsCR indicates an expected call of CreateUserToolsCR.
-func (mr *MockClientMockRecorder) CreateUserToolsCR(ctx, username, runtimeID, runtimeImage, runtimeTag interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateUserToolsCR(ctx, username, runtimeID, runtimeImage, runtimeTag interface{}, capabilities entity.Capabilities) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserToolsCR", reflect.TypeOf((*MockClient)(nil).CreateUserToolsCR), ctx, username, runtimeID, runtimeImage, runtimeTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserToolsCR", reflect.TypeOf((*MockClient)(nil).CreateUserToolsCR), ctx, username, runtimeID, runtimeImage, runtimeTag, capabilities)
 }
 
 // DeleteUserServiceAccount mocks base method.

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -109,7 +109,7 @@ func (k k8sClient) GetRuntimeIDFromUserTools(ctx context.Context, username strin
 	return "", nil
 }
 
-// GetCapabilitiesIDFromUserTools returns the runtimeId that the user tools runtime POD is using.
+// GetCapabilitiesIDFromUserTools returns the capabilityId that the user tools runtime POD is using.
 func (k k8sClient) GetCapabilitiesIDFromUserTools(ctx context.Context, username string) (string, error) {
 	pod, err := k.getUserToolsPod(ctx, username)
 	if err != nil {

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -198,8 +198,6 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 		capabilities,
 	)
 
-	k.logger.Infof("Ey this is the get definition: %w", definition)
-
 	k.logger.Infof("Creating users tools: %#v", definition.Object)
 	_, err = k.userToolsRes.Namespace(k.cfg.Kubernetes.Namespace).Create(ctx, definition, metav1.CreateOptions{})
 

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -198,6 +198,8 @@ func (k *k8sClient) createUserToolsDefinition(ctx context.Context, username, use
 		capabilities,
 	)
 
+	k.logger.Infof("Ey this is the get definition: %w", definition)
+
 	k.logger.Infof("Creating users tools: %#v", definition.Object)
 	_, err = k.userToolsRes.Namespace(k.cfg.Kubernetes.Namespace).Create(ctx, definition, metav1.CreateOptions{})
 
@@ -229,8 +231,8 @@ func (k *k8sClient) getUserToolsDefinition(
 			},
 			"spec": map[string]interface{}{
 				"nodeSelector": capabilities.GetNodeSelectors(),
-				//"affinity": capabilities.GetAffinities(),
-				//"tolerations": capabilities.GetTolerations(),
+				//"affinity": capabilities.GetAffinities(), // TODO add affinity to specs
+				//"tolerations": capabilities.GetTolerations(), // TODO add tolerations to specs
 				"domain": k.cfg.BaseDomainName,
 				"ingress": map[string]interface{}{
 					"annotations": ingressAnnotations,

--- a/app/api/infrastructure/k8s/usertools.go
+++ b/app/api/infrastructure/k8s/usertools.go
@@ -245,8 +245,8 @@ func (k *k8sClient) getUserToolsDefinition(
 			},
 			"spec": map[string]interface{}{
 				"nodeSelector": capabilities.GetNodeSelectors(),
-				//"affinity": capabilities.GetAffinities(), // TODO add affinity to specs
-				//"tolerations": capabilities.GetTolerations(), // TODO add tolerations to specs
+				// "affinity": capabilities.GetAffinities(), // TODO add affinity to specs
+				// "tolerations": capabilities.GetTolerations(), // TODO add tolerations to specs
 				"domain": k.cfg.BaseDomainName,
 				"ingress": map[string]interface{}{
 					"annotations": ingressAnnotations,

--- a/app/api/infrastructure/repository/capabilities.go
+++ b/app/api/infrastructure/repository/capabilities.go
@@ -29,6 +29,10 @@ func NewCapabilitiesMongoDBRepo(logger logging.Logger, client *mongo.Client, dbN
 func (m *capabilitiesMongoDBRepo) Get(ctx context.Context, id string) (entity.Capabilities, error) {
 	capability := entity.Capabilities{}
 
+	if &id == nil {
+		return capability, entity.ErrCapabilitiesNotFound
+	}
+
 	response := m.collection.FindOne(ctx, bson.M{"_id": id})
 	if err := response.Err(); errors.Is(err, mongo.ErrNoDocuments) {
 		return capability, entity.ErrCapabilitiesNotFound

--- a/app/api/infrastructure/repository/capabilities.go
+++ b/app/api/infrastructure/repository/capabilities.go
@@ -27,21 +27,21 @@ func NewCapabilitiesMongoDBRepo(logger logging.Logger, client *mongo.Client, dbN
 
 // Get retrieves a capabilities struct using an identifier.
 func (m *capabilitiesMongoDBRepo) Get(ctx context.Context, id string) (entity.Capabilities, error) {
-	cap := entity.Capabilities{}
+	capability := entity.Capabilities{}
 
 	response := m.collection.FindOne(ctx, bson.M{"_id": id})
 	if err := response.Err(); errors.Is(err, mongo.ErrNoDocuments) {
-		return cap, entity.ErrCapabilitiesNotFound
+		return capability, entity.ErrCapabilitiesNotFound
 	} else if err != nil {
-		return cap, err
+		return capability, err
 	}
 
-	err := response.Decode(&cap)
+	err := response.Decode(&capability)
 	if response.Err() != nil {
-		return cap, err
+		return capability, err
 	}
 
-	return cap, nil
+	return capability, nil
 }
 
 // Find all the capabilities in the database.

--- a/app/api/infrastructure/repository/capabilities.go
+++ b/app/api/infrastructure/repository/capabilities.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
+
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+	"github.com/konstellation-io/kdl-server/app/api/pkg/logging"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const capabilitiesCollName = "capabilities"
+
+type capabilityDTO struct {
+	ID         primitive.ObjectID  `bson:"_id"`
+	Capability entity.Capabilities `bson:"capabilities"`
+}
+
+type capabilitiesMongoDBRepo struct {
+	logger     logging.Logger
+	collection *mongo.Collection
+}
+
+// NewCapabilitiesMongoDBRepo implements project.Repository interface.
+func NewCapabilitiesMongoDBRepo(logger logging.Logger, client *mongo.Client, dbName string) capabilities.Repository {
+	collection := client.Database(dbName).Collection(capabilitiesCollName)
+	return &capabilitiesMongoDBRepo{logger, collection}
+}
+
+// Get retrieves a capabilities struct using an identifier.
+func (m *capabilitiesMongoDBRepo) Get(ctx context.Context, id string) (entity.Capabilities, error) {
+	cap := entity.Capabilities{}
+
+	response := m.collection.FindOne(ctx, bson.M{"_id": id})
+	if err := response.Err(); errors.Is(err, mongo.ErrNoDocuments) {
+		return cap, entity.ErrCapabilitiesNotFound
+	} else if err != nil {
+		return cap, err
+	}
+
+	err := response.Decode(&cap)
+	if response.Err() != nil {
+		return cap, err
+	}
+
+	return cap, nil
+}
+
+// FindAll retrieves all capabilities.
+func (m *capabilitiesMongoDBRepo) FindAll(ctx context.Context) ([]entity.Capabilities, error) {
+	caps := []entity.Capabilities{}
+
+	response, err := m.collection.Find(ctx, bson.M{})
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return caps, entity.ErrCapabilitiesNotFound
+	} else if err != nil {
+		return caps, err
+	}
+
+	err = response.Decode(&caps)
+	if response.Err() != nil {
+		return caps, err
+	}
+
+	return caps, nil
+}

--- a/app/api/infrastructure/repository/capabilities.go
+++ b/app/api/infrastructure/repository/capabilities.go
@@ -9,16 +9,10 @@ import (
 	"github.com/konstellation-io/kdl-server/app/api/entity"
 	"github.com/konstellation-io/kdl-server/app/api/pkg/logging"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 const capabilitiesCollName = "capabilities"
-
-type capabilityDTO struct {
-	ID         primitive.ObjectID  `bson:"_id"`
-	Capability entity.Capabilities `bson:"capabilities"`
-}
 
 type capabilitiesMongoDBRepo struct {
 	logger     logging.Logger
@@ -50,7 +44,7 @@ func (m *capabilitiesMongoDBRepo) Get(ctx context.Context, id string) (entity.Ca
 	return cap, nil
 }
 
-// FindAll retrieves all capabilities.
+// Find all the capabilities in the database.
 func (m *capabilitiesMongoDBRepo) FindAll(ctx context.Context) ([]entity.Capabilities, error) {
 	caps := []entity.Capabilities{}
 
@@ -61,7 +55,7 @@ func (m *capabilitiesMongoDBRepo) FindAll(ctx context.Context) ([]entity.Capabil
 		return caps, err
 	}
 
-	err = response.Decode(&caps)
+	err = response.All(ctx, &caps)
 	if response.Err() != nil {
 		return caps, err
 	}

--- a/app/api/infrastructure/repository/project.go
+++ b/app/api/infrastructure/repository/project.go
@@ -187,7 +187,7 @@ func (m *projectMongoDBRepo) findOne(ctx context.Context, filters bson.M) (entit
 
 	dto := projectDTO{}
 
-	err := m.collection.FindOne(ctx, filters).Decode(&dto) // TODO fix gestion errores
+	err := m.collection.FindOne(ctx, filters).Decode(&dto)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return entity.Project{}, entity.ErrProjectNotFound
 	}

--- a/app/api/infrastructure/repository/project.go
+++ b/app/api/infrastructure/repository/project.go
@@ -187,7 +187,7 @@ func (m *projectMongoDBRepo) findOne(ctx context.Context, filters bson.M) (entit
 
 	dto := projectDTO{}
 
-	err := m.collection.FindOne(ctx, filters).Decode(&dto)
+	err := m.collection.FindOne(ctx, filters).Decode(&dto) // TODO fix gestion errores
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return entity.Project{}, entity.ErrProjectNotFound
 	}

--- a/app/api/infrastructure/repository/runtime.go
+++ b/app/api/infrastructure/repository/runtime.go
@@ -34,7 +34,6 @@ type runtimeMongoDBRepo struct {
 func (m *runtimeMongoDBRepo) Get(ctx context.Context, id string) (entity.Runtime, error) {
 	idFromHex, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
-		m.logger.Errorf("Error writting primitive: %w", err)
 		return entity.Runtime{}, err
 	}
 

--- a/app/api/infrastructure/repository/runtime.go
+++ b/app/api/infrastructure/repository/runtime.go
@@ -34,6 +34,7 @@ type runtimeMongoDBRepo struct {
 func (m *runtimeMongoDBRepo) Get(ctx context.Context, id string) (entity.Runtime, error) {
 	idFromHex, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
+		m.logger.Errorf("Error writting primitive: %w", err)
 		return entity.Runtime{}, err
 	}
 

--- a/app/api/usecase/capabilities/interactor.go
+++ b/app/api/usecase/capabilities/interactor.go
@@ -57,6 +57,7 @@ func (i *interactor) GetCapabilities(ctx context.Context) ([]model.Capability, e
 	return capabilitiesList, err
 }
 
+// Retrieve the running capability
 func (i *interactor) GetRunningCapability(ctx context.Context, username string) (*model.Capability, error) {
 	capabilityId, err := i.k8sClient.GetCapabilitiesIDFromUserTools(ctx, username)
 	if err != nil {
@@ -64,7 +65,7 @@ func (i *interactor) GetRunningCapability(ctx context.Context, username string) 
 	}
 
 	if capabilityId != "" {
-		i.logger.Infof("Capability in runtime POD " + capabilityId)
+		i.logger.Infof("Capability in runtime POD: %w", capabilityId)
 
 		capability, err := i.repo.Get(ctx, capabilityId)
 		if err != nil {

--- a/app/api/usecase/capabilities/interactor.go
+++ b/app/api/usecase/capabilities/interactor.go
@@ -49,7 +49,7 @@ func (i *interactor) GetCapabilities(ctx context.Context) ([]model.Capability, e
 
 	i.logger.Infof("Retrieved capabilities: %w", capabilities)
 
-	var capabilitiesList []model.Capability
+	capabilitiesList := make([]model.Capability, len(capabilities))
 	for _, element := range capabilities {
 		capabilitiesList = append(capabilitiesList, model.Capability{ID: element.ID, Name: element.Name, Default: element.Default})
 	}
@@ -57,17 +57,17 @@ func (i *interactor) GetCapabilities(ctx context.Context) ([]model.Capability, e
 	return capabilitiesList, err
 }
 
-// Retrieve the running capability
+// Retrieve the running capability.
 func (i *interactor) GetRunningCapability(ctx context.Context, username string) (*model.Capability, error) {
-	capabilityId, err := i.k8sClient.GetCapabilitiesIDFromUserTools(ctx, username)
+	capabilityID, err := i.k8sClient.GetCapabilitiesIDFromUserTools(ctx, username)
 	if err != nil {
 		return nil, err
 	}
 
-	if capabilityId != "" {
-		i.logger.Infof("Capability in runtime POD: %w", capabilityId)
+	if capabilityID != "" {
+		i.logger.Infof("Capability in runtime POD: %w", capabilityID)
 
-		capability, err := i.repo.Get(ctx, capabilityId)
+		capability, err := i.repo.Get(ctx, capabilityID)
 		if err != nil {
 			return nil, err
 		}

--- a/app/api/usecase/capabilities/interactor.go
+++ b/app/api/usecase/capabilities/interactor.go
@@ -49,7 +49,8 @@ func (i *interactor) GetCapabilities(ctx context.Context) ([]model.Capability, e
 
 	i.logger.Infof("Retrieved capabilities: %w", capabilities)
 
-	capabilitiesList := make([]model.Capability, len(capabilities))
+	//nolint:prealloc // No need to preallocate.
+	var capabilitiesList []model.Capability
 	for _, element := range capabilities {
 		capabilitiesList = append(capabilitiesList, model.Capability{ID: element.ID, Name: element.Name, Default: element.Default})
 	}

--- a/app/api/usecase/capabilities/interactor.go
+++ b/app/api/usecase/capabilities/interactor.go
@@ -1,0 +1,78 @@
+package capabilities
+
+import (
+	"context"
+	"errors"
+
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/graph/model"
+
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/k8s"
+	"github.com/konstellation-io/kdl-server/app/api/pkg/logging"
+)
+
+var (
+	ErrStopUserTools   = errors.New("cannot stop uninitialized user tools")
+	ErrUserToolsActive = errors.New("it is not possible to regenerate SSH keys with the usertools active")
+)
+
+type interactor struct {
+	logger    logging.Logger
+	cfg       config.Config
+	repo      Repository
+	k8sClient k8s.Client
+}
+
+// NewInteractor factory function.
+func NewInteractor(
+	logger logging.Logger,
+	cfg config.Config,
+	repo Repository,
+	k8sClient k8s.Client,
+) UseCase {
+	return &interactor{
+		logger:    logger,
+		cfg:       cfg,
+		repo:      repo,
+		k8sClient: k8sClient,
+	}
+}
+
+// Retrieve all capabilities.
+func (i *interactor) GetCapabilities(ctx context.Context) ([]model.Capability, error) {
+	i.logger.Infof("Find all capabilities")
+	capabilities, err := i.repo.FindAll(ctx)
+
+	if err != nil {
+		return []model.Capability{}, err
+	}
+
+	i.logger.Infof("Retrieved capabilities: %w", capabilities)
+
+	var capabilitiesList []model.Capability
+	for _, element := range capabilities {
+		capabilitiesList = append(capabilitiesList, model.Capability{ID: element.ID, Name: element.Name, Default: element.Default})
+	}
+
+	return capabilitiesList, err
+}
+
+func (i *interactor) GetRunningCapability(ctx context.Context, username string) (*model.Capability, error) {
+	capabilityId, err := i.k8sClient.GetCapabilitiesIDFromUserTools(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+
+	if capabilityId != "" {
+		i.logger.Infof("Capability in runtime POD " + capabilityId)
+
+		capability, err := i.repo.Get(ctx, capabilityId)
+		if err != nil {
+			return nil, err
+		}
+
+		return &model.Capability{ID: capability.ID, Name: capability.Name, Default: capability.Default}, nil
+	}
+
+	return nil, nil
+}

--- a/app/api/usecase/capabilities/interactor_test.go
+++ b/app/api/usecase/capabilities/interactor_test.go
@@ -1,0 +1,92 @@
+package capabilities_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/graph/model"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/k8s"
+	"github.com/konstellation-io/kdl-server/app/api/pkg/logging"
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
+)
+
+type capabilitiesSuite struct {
+	ctrl       *gomock.Controller
+	interactor capabilities.UseCase
+	mocks      capabilitiesMocks
+}
+
+type capabilitiesMocks struct {
+	logger    *logging.MockLogger
+	cfg       config.Config
+	repo      *capabilities.MockRepository
+	k8sClient *k8s.MockClient
+}
+
+func newCapabilitiesSuite(t *testing.T, cfg *config.Config) *capabilitiesSuite {
+	ctrl := gomock.NewController(t)
+	logger := logging.NewMockLogger(ctrl)
+	repo := capabilities.NewMockRepository(ctrl)
+	k8sClient := k8s.NewMockClient(ctrl)
+
+	logging.AddLoggerExpects(logger)
+
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	interactor := capabilities.NewInteractor(logger, *cfg, repo, k8sClient)
+
+	return &capabilitiesSuite{
+		ctrl:       ctrl,
+		interactor: interactor,
+		mocks: capabilitiesMocks{
+			logger:    logger,
+			cfg:       *cfg,
+			repo:      repo,
+			k8sClient: k8sClient,
+		},
+	}
+}
+
+func TestInteractor_GetAllCapabilities(t *testing.T) {
+	s := newCapabilitiesSuite(t, nil)
+	defer s.ctrl.Finish()
+
+	const (
+		capabilitiesID   = "test_id"
+		capabilitiesName = "Test capabilities 1"
+	)
+
+	nodeSelectors := map[string]string{
+		"key1": "value1",
+	}
+	affinities := []string{}
+	taints := []string{}
+	ctx := context.Background()
+
+	returnedCapabilities := entity.Capabilities{
+		ID:            capabilitiesID,
+		Name:          capabilitiesName,
+		NodeSelectors: nodeSelectors,
+		Affinities:    affinities,
+		Taints:        taints,
+	}
+	expectedCapabilities := model.Capability{
+		ID:   capabilitiesID,
+		Name: capabilitiesName,
+	}
+
+	s.mocks.repo.EXPECT().FindAll(ctx).Return([]entity.Capabilities{returnedCapabilities}, nil)
+
+	createdCapabilities, err := s.interactor.GetCapabilities(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, []model.Capability{expectedCapabilities}, createdCapabilities)
+}

--- a/app/api/usecase/capabilities/interface.go
+++ b/app/api/usecase/capabilities/interface.go
@@ -1,0 +1,21 @@
+package capabilities
+
+//go:generate mockgen -source=${GOFILE} -destination=mocks_${GOFILE} -package=${GOPACKAGE}
+
+import (
+	"context"
+
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+)
+
+// Repository interface to retrieve and persists projects.
+type Repository interface {
+	Get(ctx context.Context, id string) (entity.Capabilities, error)
+	FindAll(ctx context.Context) ([]entity.Capabilities, error)
+}
+
+// UseCase interface to manage all operations related with projects.
+type UseCase interface {
+	FindAll(ctx context.Context) ([]entity.Project, error)
+	GetByID(ctx context.Context, id string) (entity.Project, error)
+}

--- a/app/api/usecase/capabilities/interface.go
+++ b/app/api/usecase/capabilities/interface.go
@@ -9,13 +9,13 @@ import (
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/graph/model"
 )
 
-// Repository interface to retrieve and persists projects.
+// Repository interface to retrieve and persists capabilites.
 type Repository interface {
 	Get(ctx context.Context, id string) (entity.Capabilities, error)
 	FindAll(ctx context.Context) ([]entity.Capabilities, error)
 }
 
-// UseCase interface to manage all operations related with projects.
+// UseCase interface to manage all operations related with capabilities.
 type UseCase interface {
 	GetCapabilities(ctx context.Context) ([]model.Capability, error)
 	GetRunningCapability(ctx context.Context, username string) (*model.Capability, error)

--- a/app/api/usecase/capabilities/interface.go
+++ b/app/api/usecase/capabilities/interface.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/konstellation-io/kdl-server/app/api/entity"
+	"github.com/konstellation-io/kdl-server/app/api/infrastructure/graph/model"
 )
 
 // Repository interface to retrieve and persists projects.
@@ -16,6 +17,6 @@ type Repository interface {
 
 // UseCase interface to manage all operations related with projects.
 type UseCase interface {
-	FindAll(ctx context.Context) ([]entity.Project, error)
-	GetByID(ctx context.Context, id string) (entity.Project, error)
+	GetCapabilities(ctx context.Context) ([]model.Capability, error)
+	GetRunningCapability(ctx context.Context, username string) (*model.Capability, error)
 }

--- a/app/api/usecase/capabilities/interface.go
+++ b/app/api/usecase/capabilities/interface.go
@@ -9,7 +9,7 @@ import (
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/graph/model"
 )
 
-// Repository interface to retrieve and persists capabilites.
+// Repository interface to retrieve and persists capabilities.
 type Repository interface {
 	Get(ctx context.Context, id string) (entity.Capabilities, error)
 	FindAll(ctx context.Context) ([]entity.Capabilities, error)

--- a/app/api/usecase/capabilities/mock_interface.go
+++ b/app/api/usecase/capabilities/mock_interface.go
@@ -78,6 +78,7 @@ type MockUseCaseMockRecorder struct {
 func NewMockUseCase(ctrl *gomock.Controller) *MockUseCase {
 	mock := &MockUseCase{ctrl: ctrl}
 	mock.recorder = &MockUseCaseMockRecorder{mock}
+
 	return mock
 }
 
@@ -92,6 +93,7 @@ func (m *MockUseCase) GetCapabilities(ctx context.Context) ([]entity.Capabilitie
 	ret := m.ctrl.Call(m, "GetCapabilities", ctx)
 	ret0, _ := ret[0].([]entity.Capabilities)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 

--- a/app/api/usecase/capabilities/mock_interface.go
+++ b/app/api/usecase/capabilities/mock_interface.go
@@ -22,6 +22,7 @@ type MockRepositoryMockRecorder struct {
 func NewMockRepository(ctrl *gomock.Controller) *MockRepository {
 	mock := &MockRepository{ctrl: ctrl}
 	mock.recorder = &MockRepositoryMockRecorder{mock}
+
 	return mock
 }
 
@@ -36,6 +37,7 @@ func (m *MockRepository) FindAll(ctx context.Context) ([]entity.Capabilities, er
 	ret := m.ctrl.Call(m, "FindAll", ctx)
 	ret0, _ := ret[0].([]entity.Capabilities)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 
@@ -51,6 +53,7 @@ func (m *MockRepository) Get(ctx context.Context, id string) (entity.Capabilitie
 	ret := m.ctrl.Call(m, "Get", ctx, id)
 	ret0, _ := ret[0].(entity.Capabilities)
 	ret1, _ := ret[1].(error)
+
 	return ret0, ret1
 }
 

--- a/app/api/usecase/capabilities/mock_interface.go
+++ b/app/api/usecase/capabilities/mock_interface.go
@@ -1,0 +1,99 @@
+package capabilities
+
+import (
+	context "context"
+	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+)
+
+type MockRepository struct {
+	ctrl     *gomock.Controller
+	recorder *MockRepositoryMockRecorder
+}
+
+// MockRepositoryMockRecorder is the mock recorder for MockRepository.
+type MockRepositoryMockRecorder struct {
+	mock *MockRepository
+}
+
+// NewMockRepository creates a new mock instance.
+func NewMockRepository(ctrl *gomock.Controller) *MockRepository {
+	mock := &MockRepository{ctrl: ctrl}
+	mock.recorder = &MockRepositoryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
+	return m.recorder
+}
+
+// FindAll mocks base method.
+func (m *MockRepository) FindAll(ctx context.Context) ([]entity.Capabilities, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindAll", ctx)
+	ret0, _ := ret[0].([]entity.Capabilities)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAll indicates an expected call of FindAll.
+func (mr *MockRepositoryMockRecorder) FindAll(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockRepository)(nil).FindAll), ctx)
+}
+
+// Get mocks base method.
+func (m *MockRepository) Get(ctx context.Context, id string) (entity.Capabilities, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, id)
+	ret0, _ := ret[0].(entity.Capabilities)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockRepositoryMockRecorder) Get(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRepository)(nil).Get), ctx, id)
+}
+
+// MockUseCase is a mock of UseCase interface.
+type MockUseCase struct {
+	ctrl     *gomock.Controller
+	recorder *MockUseCaseMockRecorder
+}
+
+// MockUseCaseMockRecorder is the mock recorder for MockUseCase.
+type MockUseCaseMockRecorder struct {
+	mock *MockUseCase
+}
+
+// NewMockUseCase creates a new mock instance.
+func NewMockUseCase(ctrl *gomock.Controller) *MockUseCase {
+	mock := &MockUseCase{ctrl: ctrl}
+	mock.recorder = &MockUseCaseMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockUseCase) EXPECT() *MockUseCaseMockRecorder {
+	return m.recorder
+}
+
+// GetCapabilites mocks base method.
+func (m *MockUseCase) GetCapabilities(ctx context.Context) ([]entity.Capabilities, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCapabilities", ctx)
+	ret0, _ := ret[0].([]entity.Capabilities)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCapabilites indicates an expected call of GetCapabilites.
+func (mr *MockUseCaseMockRecorder) GetCapabilities(ctx context.Context) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapabilities", reflect.TypeOf((*MockUseCase)(nil).GetCapabilities), ctx)
+}

--- a/app/api/usecase/project/interactor.go
+++ b/app/api/usecase/project/interactor.go
@@ -136,14 +136,17 @@ func NewInteractor(deps *InteractorDeps) UseCase {
 	}
 }
 
-// Create stores into the DB a new project.
-// Depending on the repository type:
-//  - For internal repositories creates a repository in Gitea.
-//  - For external repositories, mirrors the external repository in Gitea.
-//  - Create a k8s KDLProject containing a MLFLow instance
-//  - Create Minio bucket
-//  - Create Minio folders
-//  - Activate Drone.io repo
+/*
+Create stores into the DB a new project.
+Depending on the repository type:
+
+  - For internal repositories creates a repository in Gitea.
+  - For external repositories, mirrors the external repository in Gitea.
+  - Create a k8s KDLProject containing a MLFLow instance
+  - Create Minio bucket
+  - Create Minio folders
+  - Activate Drone.io repo.
+*/
 func (i *interactor) Create(ctx context.Context, opt CreateProjectOption) (entity.Project, error) {
 	// Validate the creation input
 	err := opt.Validate()

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -166,7 +166,6 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 		// ignore the user returned by the stop, as it the same as we already have
 		_, err := i.StopTools(ctx, username)
 		if err != nil {
-			i.logger.Errorf("Error stoping user tools: %w", err)
 			return entity.User{}, err
 		}
 	}
@@ -176,7 +175,6 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 	if runtimeID != nil {
 		r, err := i.repoRuntimes.Get(ctx, *runtimeID)
 		if err != nil {
-			i.logger.Errorf("Error retrieving runtime with id %s: %w", *runtimeID, err)
 			return entity.User{}, err
 		}
 
@@ -193,7 +191,6 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 
 	capabilities, err := i.repoCapabilities.Get(ctx, *capabilitiesId)
 	if err != nil {
-		i.logger.Errorf("Error retrieving capabilities: %w", err)
 		return entity.User{}, err
 	}
 

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -191,12 +191,12 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 
 	// TODO replace with capabilities retrieved from the mongo repository
 	capabilities, err := i.repoCapabilities.Get(ctx, "test_id")
-	i.logger.Infof("Ey this is the get error: %s", err.Error())
 	if err != nil {
+		i.logger.Infof("Ey this is the get error: %s", err.Error())
 		return entity.User{}, err
 	}
-	// capabilities := entity.MockCapabilities() // mock mongoDB get
 
+	i.logger.Debugf("------------------ %+v", capabilities)
 	i.logger.Infof("Creating user tools for user: \"%s\"", username)
 
 	err = i.k8sClient.CreateUserToolsCR(ctx, username, rID, rImage, rTag, capabilities)

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -150,7 +150,7 @@ func (i *interactor) GetByUsername(ctx context.Context, username string) (entity
 
 // StartTools creates a user-tools CustomResource in K8s to initialize the VSCode and Jupyter for the given username.
 // If there are already a user-tools for the user, they are replaced (stop + start new).
-func (i *interactor) StartTools(ctx context.Context, username string, runtimeID *string, capabilitiesId *string) (entity.User, error) {
+func (i *interactor) StartTools(ctx context.Context, username string, runtimeID, capabilitiesID *string) (entity.User, error) {
 	user, err := i.repo.GetByUsername(ctx, username)
 	if err != nil {
 		return entity.User{}, err
@@ -189,15 +189,15 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 		i.logger.Debugf("Using default runtime image \"%s:%s\"", rImage, rTag)
 	}
 
-	capabilities, err := i.repoCapabilities.Get(ctx, *capabilitiesId)
+	capability, err := i.repoCapabilities.Get(ctx, *capabilitiesID)
 	if err != nil {
 		return entity.User{}, err
 	}
 
-	i.logger.Debugf("------------------ %+v", capabilities)
+	i.logger.Debugf("------------------ %+v", capability)
 	i.logger.Infof("Creating user tools for user: \"%s\"", username)
 
-	err = i.k8sClient.CreateUserToolsCR(ctx, username, rID, rImage, rTag, capabilities)
+	err = i.k8sClient.CreateUserToolsCR(ctx, username, rID, rImage, rTag, capability)
 	if err != nil {
 		return entity.User{}, err
 	}

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -185,9 +185,11 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 		i.logger.Debugf("Using default runtime image \"%s:%s\"", rImage, rTag)
 	}
 
+	capabilities := entity.MockCapabilities() // mock mongoDB get
+
 	i.logger.Infof("Creating user tools for user: \"%s\"", username)
 
-	err = i.k8sClient.CreateUserToolsCR(ctx, username, rID, rImage, rTag)
+	err = i.k8sClient.CreateUserToolsCR(ctx, username, rID, rImage, rTag, capabilities)
 	if err != nil {
 		return entity.User{}, err
 	}

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -9,6 +9,7 @@ import (
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
 	"github.com/konstellation-io/kdl-server/app/api/entity"
@@ -26,15 +27,16 @@ var (
 )
 
 type interactor struct {
-	logger       logging.Logger
-	cfg          config.Config
-	repo         Repository
-	repoRuntimes runtime.Repository
-	sshGenerator sshhelper.SSHKeyGenerator
-	clock        clock.Clock
-	giteaService giteaservice.GiteaClient
-	k8sClient    k8s.Client
-	scheduler    cron.Scheduler
+	logger           logging.Logger
+	cfg              config.Config
+	repo             Repository
+	repoRuntimes     runtime.Repository
+	repoCapabilities capabilities.Repository
+	sshGenerator     sshhelper.SSHKeyGenerator
+	clock            clock.Clock
+	giteaService     giteaservice.GiteaClient
+	k8sClient        k8s.Client
+	scheduler        cron.Scheduler
 }
 
 // NewInteractor factory function.
@@ -43,21 +45,23 @@ func NewInteractor(
 	cfg config.Config,
 	repo Repository,
 	repoRuntimes runtime.Repository,
+	repoCapabilities capabilities.Repository,
 	sshGenerator sshhelper.SSHKeyGenerator,
 	c clock.Clock,
 	giteaService giteaservice.GiteaClient,
 	k8sClient k8s.Client,
 ) UseCase {
 	return &interactor{
-		logger:       logger,
-		cfg:          cfg,
-		repo:         repo,
-		repoRuntimes: repoRuntimes,
-		sshGenerator: sshGenerator,
-		clock:        c,
-		giteaService: giteaService,
-		k8sClient:    k8sClient,
-		scheduler:    cron.NewScheduler(logger),
+		logger:           logger,
+		cfg:              cfg,
+		repo:             repo,
+		repoRuntimes:     repoRuntimes,
+		repoCapabilities: repoCapabilities,
+		sshGenerator:     sshGenerator,
+		clock:            c,
+		giteaService:     giteaService,
+		k8sClient:        k8sClient,
+		scheduler:        cron.NewScheduler(logger),
 	}
 }
 
@@ -146,7 +150,7 @@ func (i *interactor) GetByUsername(ctx context.Context, username string) (entity
 
 // StartTools creates a user-tools CustomResource in K8s to initialize the VSCode and Jupyter for the given username.
 // If there are already a user-tools for the user, they are replaced (stop + start new).
-func (i *interactor) StartTools(ctx context.Context, username string, runtimeID *string) (entity.User, error) {
+func (i *interactor) StartTools(ctx context.Context, username string, runtimeID *string /*TODO modify this in GraphQL to add the capabilitiesID to the call, capabilitiesId *string*/) (entity.User, error) {
 	user, err := i.repo.GetByUsername(ctx, username)
 	if err != nil {
 		return entity.User{}, err
@@ -185,7 +189,13 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID 
 		i.logger.Debugf("Using default runtime image \"%s:%s\"", rImage, rTag)
 	}
 
-	capabilities := entity.MockCapabilities() // mock mongoDB get
+	// TODO replace with capabilities retrieved from the mongo repository
+	capabilities, err := i.repoCapabilities.Get(ctx, "test_id")
+	i.logger.Infof("Ey this is the get error: %s", err.Error())
+	if err != nil {
+		return entity.User{}, err
+	}
+	// capabilities := entity.MockCapabilities() // mock mongoDB get
 
 	i.logger.Infof("Creating user tools for user: \"%s\"", username)
 

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -189,12 +189,17 @@ func (i *interactor) StartTools(ctx context.Context, username string, runtimeID,
 		i.logger.Debugf("Using default runtime image \"%s:%s\"", rImage, rTag)
 	}
 
-	capability, err := i.repoCapabilities.Get(ctx, *capabilitiesID)
-	if err != nil {
-		return entity.User{}, err
+	capability := entity.Capabilities{}
+
+	if capabilitiesID != nil {
+		retrievedCapabilities, err := i.repoCapabilities.Get(ctx, *capabilitiesID)
+		if err != nil {
+			return entity.User{}, err
+		}
+
+		capability = retrievedCapabilities
 	}
 
-	i.logger.Debugf("------------------ %+v", capability)
 	i.logger.Infof("Creating user tools for user: \"%s\"", username)
 
 	err = i.k8sClient.CreateUserToolsCR(ctx, username, rID, rImage, rTag, capability)

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gosimple/slug"
 
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
 	"github.com/golang/mock/gomock"
@@ -32,14 +33,15 @@ type userSuite struct {
 }
 
 type userMocks struct {
-	logger        *logging.MockLogger
-	cfg           config.Config
-	repo          *user.MockRepository
-	runtimeRepo   *runtime.MockRepository
-	sshGenerator  *sshhelper.MockSSHKeyGenerator
-	clock         *clock.MockClock
-	giteaService  *giteaservice.MockGiteaClient
-	k8sClientMock *k8s.MockClient
+	logger           *logging.MockLogger
+	cfg              config.Config
+	repo             *user.MockRepository
+	runtimeRepo      *runtime.MockRepository
+	capabilitiesRepo *capabilities.MockRepository
+	sshGenerator     *sshhelper.MockSSHKeyGenerator
+	clock            *clock.MockClock
+	giteaService     *giteaservice.MockGiteaClient
+	k8sClientMock    *k8s.MockClient
 }
 
 func newUserSuite(t *testing.T, cfg *config.Config) *userSuite {
@@ -47,6 +49,7 @@ func newUserSuite(t *testing.T, cfg *config.Config) *userSuite {
 	logger := logging.NewMockLogger(ctrl)
 	repo := user.NewMockRepository(ctrl)
 	repoRuntimes := runtime.NewMockRepository(ctrl)
+	repoCapabilities := capabilities.NewMockRepository(ctrl)
 	clockMock := clock.NewMockClock(ctrl)
 	sshGenerator := sshhelper.NewMockSSHKeyGenerator(ctrl)
 	giteaServiceMock := giteaservice.NewMockGiteaClient(ctrl)
@@ -58,20 +61,21 @@ func newUserSuite(t *testing.T, cfg *config.Config) *userSuite {
 		cfg = &config.Config{}
 	}
 
-	interactor := user.NewInteractor(logger, *cfg, repo, repoRuntimes, sshGenerator, clockMock, giteaServiceMock, k8sClientMock)
+	interactor := user.NewInteractor(logger, *cfg, repo, repoRuntimes, repoCapabilities, sshGenerator, clockMock, giteaServiceMock, k8sClientMock)
 
 	return &userSuite{
 		ctrl:       ctrl,
 		interactor: interactor,
 		mocks: userMocks{
-			logger:        logger,
-			cfg:           *cfg,
-			repo:          repo,
-			runtimeRepo:   repoRuntimes,
-			sshGenerator:  sshGenerator,
-			clock:         clockMock,
-			giteaService:  giteaServiceMock,
-			k8sClientMock: k8sClientMock,
+			logger:           logger,
+			cfg:              *cfg,
+			repo:             repo,
+			runtimeRepo:      repoRuntimes,
+			capabilitiesRepo: repoCapabilities,
+			sshGenerator:     sshGenerator,
+			clock:            clockMock,
+			giteaService:     giteaServiceMock,
+			k8sClientMock:    k8sClientMock,
 		},
 	}
 }
@@ -244,6 +248,16 @@ func TestInteractor_StartTools(t *testing.T) {
 		runtimeTag   = "3.9"
 	)
 
+	capabilities := entity.Capabilities{
+		ID:   "test_id",
+		Name: "Test capability",
+		NodeSelectors: map[string]string{
+			"test1": "value1",
+		},
+		Affinities: []string{},
+		Taints:     []string{},
+	}
+
 	runtimeID := "12345"
 
 	ctx := context.Background()
@@ -252,10 +266,10 @@ func TestInteractor_StartTools(t *testing.T) {
 
 	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(expectedUser, nil)
 	s.mocks.runtimeRepo.EXPECT().Get(ctx, runtimeID).Return(expectedRuntime, nil)
+	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, capabilities.ID).Return(capabilities, nil)
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).Return(toolsRunning, nil)
-	s.mocks.k8sClientMock.EXPECT().CreateUserToolsCR(ctx, username, runtimeID, runtimeImage, runtimeTag).Return(nil)
-
-	returnedUser, err := s.interactor.StartTools(ctx, username, &runtimeID)
+	s.mocks.k8sClientMock.EXPECT().CreateUserToolsCR(ctx, username, runtimeID, runtimeImage, runtimeTag, capabilities).Return(nil)
+	returnedUser, err := s.interactor.StartTools(ctx, username, &runtimeID, &capabilities.ID)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedUser, returnedUser)
@@ -276,6 +290,16 @@ func TestInteractor_StartTools_DefaultRuntime(t *testing.T) {
 		runtimeID    = "default"
 	)
 
+	capabilities := entity.Capabilities{
+		ID:   "test_id",
+		Name: "Test capability",
+		NodeSelectors: map[string]string{
+			"test1": "value1",
+		},
+		Affinities: []string{},
+		Taints:     []string{},
+	}
+
 	ctx := context.Background()
 	expectedUser := entity.User{Username: username}
 
@@ -283,12 +307,14 @@ func TestInteractor_StartTools_DefaultRuntime(t *testing.T) {
 	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(expectedUser, nil)
 	// AND the usertools for the user was not running
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).Return(toolsRunning, nil)
+
+	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, capabilities.ID).Return(capabilities, nil)
 	// AND the CR creation does not return any error
 	s.mocks.k8sClientMock.EXPECT().CreateUserToolsCR(ctx, username, runtimeID,
-		cfg.UserToolsVsCodeRuntime.Image.Repository, cfg.UserToolsVsCodeRuntime.Image.Tag).Return(nil)
+		cfg.UserToolsVsCodeRuntime.Image.Repository, cfg.UserToolsVsCodeRuntime.Image.Tag, capabilities).Return(nil)
 
 	// WHEN the tools are started
-	returnedUser, err := s.interactor.StartTools(ctx, username, nil)
+	returnedUser, err := s.interactor.StartTools(ctx, username, nil, &capabilities.ID)
 
 	// THEN
 	// There are no errors
@@ -317,6 +343,16 @@ func TestInteractor_StartTools_Replace(t *testing.T) {
 	expectedRuntime := entity.Runtime{ID: runtimeID, DockerImage: dockerImage, DockerTag: dockerTag}
 	expectedUser := entity.User{Username: username}
 
+	capabilities := entity.Capabilities{
+		ID:   "test_id",
+		Name: "Test capability",
+		NodeSelectors: map[string]string{
+			"test1": "value1",
+		},
+		Affinities: []string{},
+		Taints:     []string{},
+	}
+
 	ctx := context.Background()
 
 	// AND the user is the in repo
@@ -327,11 +363,13 @@ func TestInteractor_StartTools_Replace(t *testing.T) {
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).AnyTimes().Return(toolsRunning, nil)
 	// AND the CR deletion does not return any error
 	s.mocks.k8sClientMock.EXPECT().DeleteUserToolsCR(ctx, username).Return(nil)
+
+	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, capabilities.ID).Return(capabilities, nil)
 	// AND the CR creation does not return any error
-	s.mocks.k8sClientMock.EXPECT().CreateUserToolsCR(ctx, username, runtimeID, dockerImage, dockerTag).Return(nil)
+	s.mocks.k8sClientMock.EXPECT().CreateUserToolsCR(ctx, username, runtimeID, dockerImage, dockerTag, capabilities).Return(nil)
 
 	// WHEN the tools are started
-	returnedUser, err := s.interactor.StartTools(ctx, username, &runtimeID)
+	returnedUser, err := s.interactor.StartTools(ctx, username, &runtimeID, &capabilities.ID)
 
 	// THEN there are no errors
 	require.NoError(t, err)

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gosimple/slug"
 
 	"github.com/konstellation-io/kdl-server/app/api/infrastructure/config"
-	"github.com/konstellation-io/kdl-server/app/api/usecase/capability"
+	"github.com/konstellation-io/kdl-server/app/api/usecase/capabilities"
 	"github.com/konstellation-io/kdl-server/app/api/usecase/runtime"
 
 	"github.com/golang/mock/gomock"
@@ -37,7 +37,7 @@ type userMocks struct {
 	cfg              config.Config
 	repo             *user.MockRepository
 	runtimeRepo      *runtime.MockRepository
-	capabilitiesRepo *capability.MockRepository
+	capabilitiesRepo *capabilities.MockRepository
 	sshGenerator     *sshhelper.MockSSHKeyGenerator
 	clock            *clock.MockClock
 	giteaService     *giteaservice.MockGiteaClient
@@ -49,7 +49,7 @@ func newUserSuite(t *testing.T, cfg *config.Config) *userSuite {
 	logger := logging.NewMockLogger(ctrl)
 	repo := user.NewMockRepository(ctrl)
 	repoRuntimes := runtime.NewMockRepository(ctrl)
-	repoCapabilities := capability.NewMockRepository(ctrl)
+	repoCapabilities := capabilities.NewMockRepository(ctrl)
 	clockMock := clock.NewMockClock(ctrl)
 	sshGenerator := sshhelper.NewMockSSHKeyGenerator(ctrl)
 	giteaServiceMock := giteaservice.NewMockGiteaClient(ctrl)

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -31,7 +31,7 @@ type UseCase interface {
 	UpdateAccessLevel(ctx context.Context, userIds []string, level entity.AccessLevel) ([]entity.User, error)
 	FindAll(ctx context.Context) ([]entity.User, error)
 	GetByUsername(ctx context.Context, username string) (entity.User, error)
-	StartTools(ctx context.Context, username string, runtimeID *string, capabilitiesId *string) (entity.User, error)
+	StartTools(ctx context.Context, username string, runtimeID *string, capabilitiesID *string) (entity.User, error)
 	StopTools(ctx context.Context, username string) (entity.User, error)
 	AreToolsRunning(ctx context.Context, username string) (bool, error)
 	IsKubeconfigActive() bool

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -31,7 +31,7 @@ type UseCase interface {
 	UpdateAccessLevel(ctx context.Context, userIds []string, level entity.AccessLevel) ([]entity.User, error)
 	FindAll(ctx context.Context) ([]entity.User, error)
 	GetByUsername(ctx context.Context, username string) (entity.User, error)
-	StartTools(ctx context.Context, username string, runtimeID *string) (entity.User, error)
+	StartTools(ctx context.Context, username string, runtimeID *string, capabilitiesId *string) (entity.User, error)
 	StopTools(ctx context.Context, username string) (entity.User, error)
 	AreToolsRunning(ctx context.Context, username string) (bool, error)
 	IsKubeconfigActive() bool

--- a/app/graphql/schema.graphqls
+++ b/app/graphql/schema.graphqls
@@ -6,6 +6,8 @@ type Query {
   qualityProjectDesc(description: String!): QualityProjectDesc!
   runtimes: [Runtime!]!
   runningRuntime: Runtime
+  capabilities: [Capability!]!
+  runningCapability: Capability
   kubeconfig: String!
 }
 
@@ -36,6 +38,12 @@ type Runtime {
   dockerImage: String!
   dockerTag: String!
   runtimePod: String!
+}
+
+type Capability {
+  id: ID!
+  name: String!
+  default: Boolean!
 }
 
 type Topic {
@@ -155,6 +163,7 @@ input SetBoolFieldInput {
 input SetActiveUserToolsInput {
   active: Boolean!,
   runtimeId: String,
+  capabilitiesId: String
 }
 
 type Project {

--- a/app/ui/cypress/integration/capabilities.spec.ts
+++ b/app/ui/cypress/integration/capabilities.spec.ts
@@ -6,7 +6,7 @@ import GetSingleCapabilityQuery from '../../src/Mocks/GetSingleCapabilityQuery';
 import GetRunningCapabilitiesQuery from '../../src/Mocks/GetRunningCapabilitiesQuery';
 import GetRunningCapabilities2Query from '../../src/Mocks/GetRunningCapabilities2Query';
 import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
-import { capability, capability2 } from '../../src/Mocks/entities/capabilities';
+import { capability, capability2, capability3 } from '../../src/Mocks/entities/capabilities';
 
 describe('Capabilities Behaviour', () => {
   beforeEach(() => {
@@ -16,6 +16,107 @@ describe('Capabilities Behaviour', () => {
     cy.kstInterceptor('GetMe', { data: GetMeQuery });
     // and a list of available runtimes
     cy.kstInterceptor('GetRuntimes', { data: GetRuntimesQuery });
+  });
+
+  describe('Sorting behaviour', () => {
+
+    it('should sort the capabilities by the default values first', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the order of the capabilities is the expected
+      cy.getByTestId('capabilitiesCrumb').should('be.visible');
+      cy.getByTestId('capabilitiesCrumb').contains('Capability Name 2');
+    });
+
+    it('should sort the capabilities by the selected first then the default values', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: GetRunningCapabilitiesQuery });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the order of the capabilities is the expected
+      cy.getByTestId('capabilitiesCrumb').should('be.visible');
+      cy.getByTestId('capabilitiesCrumb').click();
+      cy.getByTestId('capabilitiesCrumb').contains('Capability Name 1');
+    });
+
+  });
+
+    describe('Default value selection behaviour', () => {
+
+    it('should select the default capability from the list of possible capabilities when there is more than one default capability by selecting the first value between the defaults', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: {capabilities: [capability, capability3, capability2]}, });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the selected capability is the expected
+      cy.getByTestId('capabilitiesCrumb').should('be.visible');
+      cy.getByTestId('capabilitiesCrumb').contains('Capability Name 2');
+    });
+
+    it('should select the default capability from the list of possible capabilities when there is just one default capability on the list', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the selected capability is the expected
+      cy.getByTestId('capabilitiesCrumb').should('be.visible');
+      cy.getByTestId('capabilitiesCrumb').contains('Capability Name 2');
+    });
+
+    it('should select the only capability available as default capability and not show the selector component', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetSingleCapabilityQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the selected capability is the expected and the crumb is hidden
+      cy.getByTestId('capabilitiesCrumb').should('be.hidden');
+      cy.getByTestId('capabilitiesCrumb').contains('Capability Name 1');
+    });
+
+    it('should not show the component and have no default value selected', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: null });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and open the details page
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().last().click();
+
+      // THEN check the select component does not exist
+      cy.getByTestId('capabilitiesCrumb').should('not.exist');
+    });
   });
 
   describe('Top bar selector behaviour', () => {

--- a/app/ui/cypress/integration/capabilities.spec.ts
+++ b/app/ui/cypress/integration/capabilities.spec.ts
@@ -305,7 +305,7 @@ describe('Capabilities Behaviour', () => {
       cy.getByTestId('capabilitiesTag').contains(capability.name);
     });
 
-    it('should show error message on capability not selected', () => {
+    it('should run as normal on capability not selected (for retrocompatibility)', () => {
       // GIVEN there is a runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
       // and the user tools are not started
@@ -326,11 +326,14 @@ describe('Capabilities Behaviour', () => {
       // and the runtime us started
       cy.getByTestId('startTools').click();
 
-      // THEN the runtime is running
+      // and the runtimes panels is opened
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+
       // THEN the runtime is running
       cy.getByTestId('capabilitiesCrumb').should('not.exist');
-      cy.getByTestId('runtimeInfoPanel').should('not.exist');
-      cy.contains('CANNOT START TOOLS').should('exist');
+      cy.getByTestId('statusTag').contains('Running');
+      cy.getByTestId('capabilitiesTag').should('not.exist');
     });
   });
 

--- a/app/ui/cypress/integration/capabilities.spec.ts
+++ b/app/ui/cypress/integration/capabilities.spec.ts
@@ -8,22 +8,6 @@ import GetRunningCapabilities2Query from '../../src/Mocks/GetRunningCapabilities
 import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
 import { capability, capability2 } from '../../src/Mocks/entities/capabilities';
 
-const isRuntimeRunning = (runtimeName: string) => {
-  cy.getByTestId('openRuntimeSettings').click();
-  cy.getByTestId('runtimesList').contains(runtimeName).click();
-
-  cy.getByTestId('runtimeInfoPanel').should('contain', runtimeName);
-  cy.getByTestId('statusTag').should('contain', 'Running');
-};
-
-const isRuntimeStopped = (runtimeName: string) => {
-  cy.getByTestId('openRuntimeSettings').click();
-  cy.getByTestId('runtimesList').contains(runtimeName).click();
-
-  cy.getByTestId('runtimeInfoPanel').should('contain', runtimeName);
-  cy.getByTestId('statusTag').should('not.exist');
-};
-
 describe('Capabilities Behaviour', () => {
   beforeEach(() => {
     // There is a list of projects
@@ -50,7 +34,7 @@ describe('Capabilities Behaviour', () => {
       cy.getByTestId('runtimesList').children().last().click();
 
       // THEN check the default capability is selected
-      cy.getByTestId('capabilitiesTag').should('not.exist')
+      cy.getByTestId('capabilitiesTag').should('not.exist');
       cy.getByTestId('capabilitiesCrumb').should('not.exist');
     });
 
@@ -69,7 +53,7 @@ describe('Capabilities Behaviour', () => {
       cy.getByTestId('runtimesList').children().last().click();
 
       // THEN check the default capability is selected
-      cy.getByTestId('capabilitiesTag').contains(capability.name)
+      cy.getByTestId('capabilitiesTag').contains(capability.name);
       cy.getByTestId('capabilitiesCrumb').should('be.hidden');
     });
 

--- a/app/ui/cypress/integration/capabilities.spec.ts
+++ b/app/ui/cypress/integration/capabilities.spec.ts
@@ -1,0 +1,312 @@
+import GetProjectsQuery from '../../src/Mocks/GetProjectsQuery';
+import GetMeQuery from '../../src/Mocks/GetMeQuery';
+import GetRuntimesQuery from '../../src/Mocks/GetRuntimesQuery';
+import GetCapabilitiesQuery from '../../src/Mocks/GetCapabilitiesQuery';
+import GetSingleCapabilityQuery from '../../src/Mocks/GetSingleCapabilityQuery';
+import GetRunningCapabilitiesQuery from '../../src/Mocks/GetRunningCapabilitiesQuery';
+import GetRunningCapabilities2Query from '../../src/Mocks/GetRunningCapabilities2Query';
+import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
+import { capability, capability2 } from '../../src/Mocks/entities/capabilities';
+
+const isRuntimeRunning = (runtimeName: string) => {
+  cy.getByTestId('openRuntimeSettings').click();
+  cy.getByTestId('runtimesList').contains(runtimeName).click();
+
+  cy.getByTestId('runtimeInfoPanel').should('contain', runtimeName);
+  cy.getByTestId('statusTag').should('contain', 'Running');
+};
+
+const isRuntimeStopped = (runtimeName: string) => {
+  cy.getByTestId('openRuntimeSettings').click();
+  cy.getByTestId('runtimesList').contains(runtimeName).click();
+
+  cy.getByTestId('runtimeInfoPanel').should('contain', runtimeName);
+  cy.getByTestId('statusTag').should('not.exist');
+};
+
+describe('Capabilities Behaviour', () => {
+  beforeEach(() => {
+    // There is a list of projects
+    cy.kstInterceptor('GetProjects', { data: GetProjectsQuery });
+    // and a user logged
+    cy.kstInterceptor('GetMe', { data: GetMeQuery });
+    // and a list of available runtimes
+    cy.kstInterceptor('GetRuntimes', { data: GetRuntimesQuery });
+  });
+
+  describe('Top bar selector behaviour', () => {
+    it('should not exist when there is no capabilities available', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: null });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and open the details page
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().last().click();
+
+      // THEN check the default capability is selected
+      cy.getByTestId('capabilitiesTag').should('not.exist')
+      cy.getByTestId('capabilitiesCrumb').should('not.exist');
+    });
+
+    it('should not show when there is one capability available, and the capability should be selected by default', () => {
+      // GIVEN there is no capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetSingleCapabilityQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and open the details page
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().last().click();
+
+      // THEN check the default capability is selected
+      cy.getByTestId('capabilitiesTag').contains(capability.name)
+      cy.getByTestId('capabilitiesCrumb').should('be.hidden');
+    });
+
+    it('should select the default capability when a project is opened', () => {
+      // GIVEN there is not running capabilites
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+      // and a list of available capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the default capability is selected
+      cy.getByTestId('capabilitiesCrumb').contains(capability2.name);
+    });
+
+    it('should select the running capability as the selected capability when a project is opened', () => {
+      // GIVEN there is not running capabilites
+      cy.kstInterceptor('GetRunningCapabilities', { data: GetRunningCapabilities2Query });
+      // and a list of available capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // THEN check the default capability is selected
+      cy.getByTestId('capabilitiesCrumb').contains(capability2.name);
+    });
+
+    it('should replace the selected capability when there is no runtime selected', () => {
+      // GIVEN there is a default running capabilites
+      cy.kstInterceptor('GetRunningCapabilities', { data: GetRunningCapabilitiesQuery });
+      //and a list of available capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is not running runtime
+      cy.kstInterceptor('GetRunningRuntime', { data: null });
+      // and user tools are not active
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and waits for the selected capability to be called
+      cy.getByTestId('capabilitiesCrumb').contains(capability.name);
+
+      // and select a different capability to open the replace tools modal
+      cy.getByTestId('capabilitiesCrumb').click();
+      cy.contains(capability2.name).click();
+
+      // and the action is confirmed
+      cy.contains('Replace Capabilities').click();
+
+      // THEN check the default capability is selected
+      cy.getByTestId('capabilitiesCrumb').contains(capability2.name);
+    });
+
+    it('should replace the selected capability when there is a runtime selected', () => {
+      // GIVEN a list of available capabilities
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is a default running capabilites
+      cy.kstInterceptor('GetRunningCapabilities', { data: GetRunningCapabilitiesQuery });
+      // and there is not running runtime
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+      // and user tools are not active
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and waits for the selected capability to be called
+      cy.getByTestId('capabilitiesCrumb').contains(capability.name);
+
+      // and select a different capability to open the replace tools modal
+      cy.getByTestId('capabilitiesCrumb').click();
+      cy.contains(capability2.name).click();
+
+      // and the action is confirmed
+      cy.contains('Replace Capabilities').click();
+
+      // THEN check the default capability is selected
+      cy.getByTestId('capabilitiesCrumb').contains(capability2.name);
+    });
+  });
+
+  describe('Left Sidebar Buttons Behaviour', () => {
+    it('should start runtime with the default capability between the existing ones', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+      // and the user tools are not started
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      //and there is a default capability selected
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtime is stopped
+      cy.getByTestId('stopTools').click();
+      cy.contains('Stop Tools').click();
+
+      // and the runtime us started
+      cy.getByTestId('startTools').click();
+
+      // and the runtimes panels is opened
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+
+      // THEN the runtime is running
+      cy.getByTestId('statusTag').contains('Running');
+      cy.getByTestId('capabilitiesTag').contains(capability2.name);
+    });
+
+    it('should start runtime with the only existing capability', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+      // and the user tools are not started
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      //and there is a default capability selected
+      cy.kstInterceptor('GetCapabilities', { data: GetSingleCapabilityQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtime is stopped
+      cy.getByTestId('stopTools').click();
+      cy.contains('Stop Tools').click();
+
+      // and the runtime us started
+      cy.getByTestId('startTools').click();
+
+      // and the runtimes panels is opened
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+
+      // THEN the runtime is running
+      cy.getByTestId('capabilitiesCrumb').should('be.hidden');
+      cy.getByTestId('statusTag').contains('Running');
+      cy.getByTestId('capabilitiesTag').contains(capability.name);
+    });
+
+    it('should show error message on capability not selected', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+      // and the user tools are not started
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      //and there is no capabilities to be selected
+      cy.kstInterceptor('GetCapabilities', { data: null });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtime is stopped
+      cy.getByTestId('stopTools').click();
+      cy.contains('Stop Tools').click();
+
+      // and the runtime us started
+      cy.getByTestId('startTools').click();
+
+      // THEN the runtime is running
+      // THEN the runtime is running
+      cy.getByTestId('capabilitiesCrumb').should('not.exist');
+      cy.getByTestId('runtimeInfoPanel').should('not.exist');
+      cy.contains('CANNOT START TOOLS').should('exist');
+    });
+  });
+
+  describe('Runtime Information Panel Behaviour', () => {
+    it('should not open the runtime information panel if there is no capabilities to be selected', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+      // and the user tools are not started
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      //and there is a default capability selected
+      cy.kstInterceptor('GetCapabilities', { data: null });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: null });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtime is stopped
+      cy.getByTestId('stopTools').click();
+      cy.contains('Stop Tools').click();
+
+      // and the runtimes panels is opened
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+
+      // THEN the runtime is running
+      cy.getByTestId('runtimeInfoPanel').should('not.exist');
+    });
+
+    it('should change the selected capability tag when the panel is opened and the capabilities are changed', () => {
+      // GIVEN there is a runtime started
+      cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
+      // and the user tools are not started
+      cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+      //and there is a default capability selected
+      cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+      // and there is not running capability
+      cy.kstInterceptor('GetRunningCapabilities', { data: GetRunningCapabilitiesQuery });
+
+      // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtimes panels is opened
+      cy.getByTestId('openRuntimeSettings').click();
+      cy.getByTestId('runtimesList').children().first().click();
+
+      // THEN the runtime is running
+      cy.getByTestId('runtimeInfoPanel').should('exist');
+      cy.getByTestId('capabilitiesTag').contains(capability.name);
+
+      // WHEN change selected capability
+      cy.getByTestId('capabilitiesCrumb').click();
+      cy.contains(capability2.name).click();
+
+      // and the action is confirmed
+      cy.contains('Replace Capabilities').click();
+
+      // THEN
+      cy.getByTestId('capabilitiesTag').contains(capability2.name);
+    });
+  });
+});

--- a/app/ui/cypress/integration/runtimes.spec.ts
+++ b/app/ui/cypress/integration/runtimes.spec.ts
@@ -1,7 +1,9 @@
 import GetProjectsQuery from '../../src/Mocks/GetProjectsQuery';
 import GetMeQuery from '../../src/Mocks/GetMeQuery';
 import GetRunningRuntimeQuery from '../../src/Mocks/GetRunningRuntimeQuery';
+import GetRunningCapabilitiesQuery from '../../src/Mocks/GetRunningCapabilitiesQuery';
 import GetRuntimesQuery from '../../src/Mocks/GetRuntimesQuery';
+import GetCapabilitiesQuery from '../../src/Mocks/GetCapabilitiesQuery';
 import { runtime2 } from '../../src/Mocks/entities/runtime';
 
 const isRuntimeRunning = (runtimeName: string) => {
@@ -28,17 +30,22 @@ describe('Runtimes Behaviour', () => {
     cy.kstInterceptor('GetMe', { data: GetMeQuery });
     // and a list of available runtimes
     cy.kstInterceptor('GetRuntimes', { data: GetRuntimesQuery });
-
-    cy.visit('http://localhost:3001');
-    cy.getByTestId('project').first().parent().click();
+    // and a list of available capabilities
+    cy.kstInterceptor('GetCapabilities', { data: GetCapabilitiesQuery });
+    // and a default running capability
+    cy.kstInterceptor('GetRunningCapabilities', { data: GetRunningCapabilitiesQuery });
   });
 
   describe('Left Sidebar Buttons Behaviour', () => {
-    it('should open runtimes panels is there is no runtime selected when start tools', () => {
+    it('should open runtimes panels if there is no runtime selected when start tools', () => {
       // GIVEN there is no runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: null });
 
       // WHEN the start runtime button on the left sidebar is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtime us started
       cy.getByTestId('startTools').click();
 
       // THEN the runtime list panel is opened
@@ -51,7 +58,12 @@ describe('Runtimes Behaviour', () => {
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
 
       // WHEN the stop runtime button is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtime is stopped
       cy.getByTestId('stopTools').click();
+
       // and the action is confirmed
       cy.contains('Stop Tools').click();
 
@@ -63,11 +75,16 @@ describe('Runtimes Behaviour', () => {
       // GIVEN there is a runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+
+      // WHEN the start runtime button is clicked
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
       // and the runtime is stopped
       cy.getByTestId('stopTools').click();
       cy.contains('Stop Tools').click();
 
-      // WHEN the start runtime button is clicked
+      // and the runtime is started
       cy.getByTestId('startTools').click();
 
       // THEN the last runtime in execution is started
@@ -81,6 +98,12 @@ describe('Runtimes Behaviour', () => {
       cy.kstInterceptor('GetRunningRuntime', { data: null });
 
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+
+      // WHEN visiting the project
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtimes panels is opened
       cy.getByTestId('openRuntimeSettings').click();
       cy.getByTestId('runtimesList').children().first().click();
       cy.getByTestId('panelStartRuntime').click();
@@ -92,11 +115,17 @@ describe('Runtimes Behaviour', () => {
     it('should stop tools with runtime info stop button', () => {
       // GIVEN there is a runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
-
-      // WHEN runtime is stopped from runtime info panel
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
+
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtimes panel is opened
       cy.getByTestId('openRuntimeSettings').click();
       cy.getByTestId('runtimesList').children().first().click();
+
+      // and the runtime is stopped
       cy.getByTestId('panelStopRuntime').click();
       cy.contains('Stop Tools').click();
 
@@ -107,11 +136,18 @@ describe('Runtimes Behaviour', () => {
     it('should replace runtime if there is a runtime running but another is started', () => {
       // GIVEN there is no runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
-
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
+
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtimes panel is opened
       cy.getByTestId('openRuntimeSettings').click();
       cy.getByTestId('runtimesList').children().last().click();
       cy.getByTestId('panelStartRuntime').click();
+
+      // and the replace tools panel is opened
       cy.contains('Replace Tools').click();
 
       // THEN the runtime is running
@@ -124,7 +160,11 @@ describe('Runtimes Behaviour', () => {
       // GIVEN there is no runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: null });
 
-      // WHEN a tool is opened
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and a tool is opened
       cy.contains('Vscode').click({ force: true });
 
       // THEN the navigation is redirected to overview page
@@ -135,7 +175,11 @@ describe('Runtimes Behaviour', () => {
       // GIVEN there is a runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
 
-      // WHEN a tool is opened
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and a tool is opened
       cy.contains('Vscode').click();
 
       // THEN the tools is open
@@ -148,9 +192,17 @@ describe('Runtimes Behaviour', () => {
 
       // and the runtime is being replaced with certain delay
       cy.kstInterceptor('SetActiveUserTools', { data: { id: true } }, { delay: 1000 });
+
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and the runtimes panel is opened
       cy.getByTestId('openRuntimeSettings').click();
       cy.getByTestId('runtimesList').children().last().click();
       cy.getByTestId('panelStartRuntime').click();
+
+      // and the replace runtime panel is opened
       cy.contains('Replace Tools').click();
 
       // WHEN try to open a user tool while request is pending
@@ -164,10 +216,14 @@ describe('Runtimes Behaviour', () => {
       // GIVEN there is a runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: { runningRuntime: null } });
 
-      // GIVEN the first runtime selected
+      // and the first runtime selected
       cy.kstInterceptor('SetActiveUserTools', { data: { id: GetRuntimesQuery.runtimes[0].id } }, { delay: 1000 });
 
-      // When we start it
+      // When the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      //and we start it
       cy.getByTestId('openRuntimeSettings').click();
       cy.getByTestId('runtimesList').children().first().click();
       cy.getByTestId('panelStartRuntime').click();
@@ -185,9 +241,14 @@ describe('Runtimes Behaviour', () => {
       // and another runtime to run
       const runtimeName = runtime2.name;
 
-      // WHEN we click the runtime we want to run on the runtimes crumb
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and we click the runtime we want to run on the runtimes crumb
       cy.getByTestId('runtimesCrumb').click();
       cy.contains(runtimeName).click();
+
       // and the action is confirmed
       cy.contains('Replace Tools').click();
 
@@ -201,6 +262,11 @@ describe('Runtimes Behaviour', () => {
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: true } });
       // and another runtime to run
       const runtimeName = runtime2.name;
+
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
       // and we stop the actual runtime
       cy.getByTestId('stopTools').click();
       cy.contains('Stop Tools').click();
@@ -217,9 +283,13 @@ describe('Runtimes Behaviour', () => {
     it('There should be only safe tags on runtime description', () => {
       // GIVEN there is a runtime started
       cy.kstInterceptor('GetRunningRuntime', { data: GetRunningRuntimeQuery });
-
-      // WHEN runtime info panel is opened
       cy.kstInterceptor('SetActiveUserTools', { data: { areToolsActive: false } });
+
+      // WHEN the project page is visited
+      cy.visit('http://localhost:3001');
+      cy.getByTestId('project').first().parent().click();
+
+      // and runtime info panel is opened
       cy.getByTestId('openRuntimeSettings').click();
       cy.getByTestId('runtimesList').children().first().click();
 

--- a/app/ui/mock-server/src/mock.js
+++ b/app/ui/mock-server/src/mock.js
@@ -20,7 +20,7 @@ module.exports = {
     project: (_, { id }) => projects.find((project) => project.id === id),
     runtimes: () => runtimes,
     capabilities: () => capabilities,
-    runningCapabilities: () => null/*capabilities[casual.integer(0, 4)]*/,
+    runningCapability: () => capabilities[casual.integer(0, 4)],
     runningRuntime: () => runtimes[casual.integer(0, 7)],
     kubeconfig: () => kubeconfig(),
   }),

--- a/app/ui/mock-server/src/mock.js
+++ b/app/ui/mock-server/src/mock.js
@@ -2,6 +2,7 @@ const casual = require('casual');
 const buildProject = require('./mocks/projectMock');
 const buildUser = require('./mocks/usersMock');
 const buildRuntime = require('./mocks/runtimeMock');
+const buildCapabilities = require('./mocks/capabilitiesMock');
 const { buildMember, meAsMember } = require('./mocks/membersMock');
 const { meId, me } = require('./mocks/meMock');
 const kubeconfig = require('./mocks/kubeconfigMock');
@@ -9,6 +10,7 @@ const kubeconfig = require('./mocks/kubeconfigMock');
 const projects = Array(8).fill(0).map(buildProject);
 const users = Array(casual.integer(20, 30)).fill(0).map(buildUser);
 const runtimes = Array(8).fill(0).map(buildRuntime);
+const capabilities = Array(2).fill(0).map(buildCapabilities);
 
 module.exports = {
   Query: () => ({
@@ -17,6 +19,8 @@ module.exports = {
     users: () => users,
     project: (_, { id }) => projects.find((project) => project.id === id),
     runtimes: () => runtimes,
+    capabilities: () => capabilities,
+    runningCapabilities: () => null/*capabilities[casual.integer(0, 4)]*/,
     runningRuntime: () => runtimes[casual.integer(0, 7)],
     kubeconfig: () => kubeconfig(),
   }),

--- a/app/ui/mock-server/src/mock.js
+++ b/app/ui/mock-server/src/mock.js
@@ -10,7 +10,7 @@ const kubeconfig = require('./mocks/kubeconfigMock');
 const projects = Array(8).fill(0).map(buildProject);
 const users = Array(casual.integer(20, 30)).fill(0).map(buildUser);
 const runtimes = Array(8).fill(0).map(buildRuntime);
-const capabilities = Array(2).fill(0).map(buildCapabilities);
+const capabilities = Array(0).fill(0).map(buildCapabilities);
 
 module.exports = {
   Query: () => ({

--- a/app/ui/mock-server/src/mocks/capabilitiesMock.js
+++ b/app/ui/mock-server/src/mocks/capabilitiesMock.js
@@ -1,0 +1,20 @@
+const casual = require('casual');
+
+casual.define('html', function () {
+  let htmlStr = "<p><b>" + casual.sentences(1) + "</b></p>"
+  htmlStr += "<ul><li>TensorFlow 2.8.0</li>"
+  htmlStr += "<li>SpaCy 3.2</li>"
+  htmlStr += "<script>alert('it's safe this html?')</script/><li>NLTK 3.7</li></ul>"
+  htmlStr += casual.sentences(10);
+  return htmlStr;
+});
+
+function buildCapabilities(_) {
+  return {
+    id: casual.uuid,
+    name: casual.name,
+    default: casual.boolean
+  };
+}
+
+module.exports = buildCapabilities;

--- a/app/ui/src/Components/Capability/Capability.module.scss
+++ b/app/ui/src/Components/Capability/Capability.module.scss
@@ -1,0 +1,46 @@
+@import 'Styles/colors';
+@import 'Styles/mixins';
+@import 'Styles/variables';
+@import 'Styles/borders';
+@import 'Styles/shadows';
+
+$shape-height: 30 * $grid-unit;
+$desc-height: 5 * $grid-unit;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: $grid-unit;
+  position: relative;
+  margin-top: 0.4 * $grid-unit;
+  flex-shrink: 0;
+  width: 100%;
+  background-color: palette(base, 400);
+  border-radius: $grid-unit;
+  border-left: 3px solid palette(base);
+  cursor: pointer;
+
+  &.active {
+    border-left: 3px solid palette(success);
+  }
+  &.loading {
+    border-left: 3px solid palette(feedback);
+  }
+  &:hover:not(.disabled) {
+    background-color: palette(base, 800);
+  }
+  .content {
+    width: 100%;
+
+    .name {
+      @include font-caption;
+      font-weight: bold;
+    }
+    .desc {
+      @include font-small;
+      color: font-color(regular);
+      max-height: 15px;
+      overflow: hidden;
+    }
+  }
+}

--- a/app/ui/src/Components/Capability/Capability.tsx
+++ b/app/ui/src/Components/Capability/Capability.tsx
@@ -7,17 +7,18 @@ import { useReactiveVar } from '@apollo/client';
 type Props = {
   capabilityName: string;
   capabilityId: string;
+  isRunning?: boolean;
   disabled?: boolean;
 };
 
-function Capability({ capabilityId, capabilityName, disabled = false }: Props) {
+function Capability({ capabilityId, capabilityName, isRunning = false, disabled = false }: Props) {
   const selectedCapability = useReactiveVar(selectedCapabilities);
 
   return (
     <div
       data-testid="capability"
       className={cx(styles.container, {
-        [styles.active]: selectedCapability?.id === capabilityId,
+        [styles.active]: isRunning,
         [styles.disabled]: disabled,
       })}
       onClick={() => {

--- a/app/ui/src/Components/Capability/Capability.tsx
+++ b/app/ui/src/Components/Capability/Capability.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styles from './Capability.module.scss';
+import cx from 'classnames';
+import { selectedCapabilities } from 'Graphql/client/cache';
+import { useReactiveVar } from '@apollo/client';
+
+type Props = {
+  capabilityName: string;
+  capabilityId: string;
+  disabled?: boolean;
+};
+
+function Capability({ capabilityId, capabilityName, disabled = false }: Props) {
+  const selectedCapability = useReactiveVar(selectedCapabilities);
+
+  return (
+    <div
+      data-testid="capability"
+      className={cx(styles.container, {
+        [styles.active]: selectedCapability?.id === capabilityId,
+        [styles.disabled]: disabled,
+      })}
+      onClick={() => {
+        if (disabled) return;
+        if (selectedCapability?.id === capabilityId) {
+          selectedCapabilities(null);
+        } else {
+          selectedCapabilities({ __typename: "Capability", id: capabilityId, name: capabilityName, default: false});
+        }
+      }}
+    >
+      <div className={styles.content}>
+        <p className={styles.name} data-testid="capabilityName">
+          {capabilityName}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default Capability;

--- a/app/ui/src/Components/Capability/Capability.tsx
+++ b/app/ui/src/Components/Capability/Capability.tsx
@@ -25,7 +25,7 @@ function Capability({ capabilityId, capabilityName, disabled = false }: Props) {
         if (selectedCapability?.id === capabilityId) {
           selectedCapabilities(null);
         } else {
-          selectedCapabilities({ __typename: "Capability", id: capabilityId, name: capabilityName, default: false});
+          selectedCapabilities({ __typename: 'Capability', id: capabilityId, name: capabilityName, default: false });
         }
       }}
     >

--- a/app/ui/src/Components/RuntimeRunner/RuntimeRunner.module.scss
+++ b/app/ui/src/Components/RuntimeRunner/RuntimeRunner.module.scss
@@ -5,6 +5,10 @@
 
 .runtimeModal {
   width: 75 * $grid-unit;
+  .title {
+    font-weight: bold;
+    text-decoration: underline;
+  }
   .runtimeModalInfo {
     margin-top: 0;
     margin-bottom: 2 * $grid-unit;
@@ -15,12 +19,12 @@
 
   &.close {
     border-left-color: palette(highlight);
-    div + div {
+    div + div + div {
       &:last-of-type {
         div > div {
           padding: $grid-unit / 2 $grid-unit * 2;
           height: auto!important;
-          &:first-of-type {
+          &:first-of-type:not(.content) {
             background: palette(highlight);
             margin: 0;
             &:active,

--- a/app/ui/src/Components/RuntimeRunner/RuntimeRunner.module.scss
+++ b/app/ui/src/Components/RuntimeRunner/RuntimeRunner.module.scss
@@ -7,7 +7,6 @@
   width: 75 * $grid-unit;
   .title {
     font-weight: bold;
-    text-decoration: underline;
   }
   .runtimeModalInfo {
     margin-top: 0;

--- a/app/ui/src/Components/RuntimeRunner/RuntimeRunner.tsx
+++ b/app/ui/src/Components/RuntimeRunner/RuntimeRunner.tsx
@@ -14,7 +14,7 @@ import Capability from 'Components/Capability/Capability';
 export enum RuntimeAction {
   Start,
   Stop,
-  ReplaceCapability
+  ReplaceCapability,
 }
 
 type Props = {
@@ -57,7 +57,7 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
     closeReplaceRuntimeModal();
   };
 
-   const handleReplaceCapability = () => {
+  const handleReplaceCapability = () => {
     if (capability != null) {
       selectedCapabilities(capability);
       if (runtime != null) {
@@ -125,18 +125,22 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
             <ModalLayoutInfo className={styles.runtimeModalInfo}>
               <div data-testid="stopToolsModal">
                 <p>You are going to stop your user tools, please confirm your choice.</p>
-                {runtimeRunning &&
+                {runtimeRunning && (
                   <div>
                     <p className={styles.title}>Runtime</p>
                     <Runtime runtime={runtimeRunning} isRunning={true} disabled={true} />
                   </div>
-                }
-                {selectedCapability &&
+                )}
+                {selectedCapability && (
                   <div>
                     <p className={styles.title}>Capabilities</p>
-                    <Capability capabilityId={selectedCapability.id} capabilityName={selectedCapability.name} disabled={true} />
+                    <Capability
+                      capabilityId={selectedCapability.id}
+                      capabilityName={selectedCapability.name}
+                      disabled={true}
+                    />
                   </div>
-                }
+                )}
               </div>
             </ModalLayoutInfo>
           </ModalContainer>
@@ -155,35 +159,39 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
             <ModalLayoutInfo className={styles.runtimeModalInfo}>
               <div>
                 <p>You are about to stop this active Runtime. ¿Are you sure?</p>
-                {runtimeRunning &&
+                {runtimeRunning && (
                   <div>
                     <p className={styles.title}>Runtime</p>
                     <Runtime runtime={runtimeRunning} isRunning={true} disabled={true} />
                   </div>
-                }
-                {selectedCapability &&
+                )}
+                {selectedCapability && (
                   <div>
                     <p className={styles.title}>Capabilities</p>
-                    <Capability capabilityId={selectedCapability.id} capabilityName={selectedCapability.name} disabled={true} />
+                    <Capability
+                      capabilityId={selectedCapability.id}
+                      capabilityName={selectedCapability.name}
+                      disabled={true}
+                    />
                   </div>
-                }
+                )}
               </div>
             </ModalLayoutInfo>
             <ModalLayoutInfo className={styles.runtimeModalInfo}>
               <div>
                 <p>And this Runtime will activate instead</p>
-                {runtime &&
+                {runtime && (
                   <div>
                     <p className={styles.title}>Runtime</p>
                     <Runtime runtime={runtime} isRunning={false} disabled={true} />
                   </div>
-                }
-                {capability &&
+                )}
+                {capability && (
                   <div>
                     <p className={styles.title}>Capabilities</p>
                     <Capability capabilityId={capability?.id} capabilityName={capability?.name} disabled={true} />
                   </div>
-                }
+                )}
               </div>
             </ModalLayoutInfo>
           </ModalContainer>
@@ -202,35 +210,39 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
             <ModalLayoutInfo className={styles.runtimeModalInfo}>
               <div>
                 <p>You are about to stop this active Runtime. ¿Are you sure?</p>
-                {runtimeRunning &&
+                {runtimeRunning && (
                   <div>
                     <p className={styles.title}>Runtime</p>
                     <Runtime runtime={runtimeRunning} isRunning={true} disabled={true} />
                   </div>
-                }
-                {selectedCapability &&
+                )}
+                {selectedCapability && (
                   <div>
                     <p className={styles.title}>Capabilities</p>
-                    <Capability capabilityId={selectedCapability.id} capabilityName={selectedCapability.name} disabled={true} />
+                    <Capability
+                      capabilityId={selectedCapability.id}
+                      capabilityName={selectedCapability.name}
+                      disabled={true}
+                    />
                   </div>
-                }
+                )}
               </div>
             </ModalLayoutInfo>
             <ModalLayoutInfo className={styles.runtimeModalInfo}>
               <div>
                 <p>And this Runtime will activate instead</p>
-                {runtime &&
+                {runtime && (
                   <div>
                     <p className={styles.title}>Runtime</p>
                     <Runtime runtime={runtime} isRunning={false} disabled={true} />
                   </div>
-                }
-                {capability &&
+                )}
+                {capability && (
                   <div>
                     <p className={styles.title}>Capabilities</p>
                     <Capability capabilityId={capability?.id} capabilityName={capability?.name} disabled={true} />
                   </div>
-                }
+                )}
               </div>
             </ModalLayoutInfo>
           </ModalContainer>

--- a/app/ui/src/Components/RuntimeRunner/RuntimeRunner.tsx
+++ b/app/ui/src/Components/RuntimeRunner/RuntimeRunner.tsx
@@ -137,6 +137,7 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
                     <Capability
                       capabilityId={selectedCapability.id}
                       capabilityName={selectedCapability.name}
+                      isRunning={true}
                       disabled={true}
                     />
                   </div>
@@ -171,6 +172,7 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
                     <Capability
                       capabilityId={selectedCapability.id}
                       capabilityName={selectedCapability.name}
+                      isRunning={true}
                       disabled={true}
                     />
                   </div>
@@ -222,6 +224,7 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
                     <Capability
                       capabilityId={selectedCapability.id}
                       capabilityName={selectedCapability.name}
+                      isRunning={true}
                       disabled={true}
                     />
                   </div>

--- a/app/ui/src/Components/RuntimeRunner/RuntimeRunner.tsx
+++ b/app/ui/src/Components/RuntimeRunner/RuntimeRunner.tsx
@@ -27,7 +27,6 @@ type Props = {
 const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
   const { startRuntime, pauseRuntime } = useRuntime(runtime);
   const selectedCapability = useReactiveVar(selectedCapabilities);
-  const { activate: showErrorModal, deactivate: closeErrorModal, value: isErrorModalVisible } = useBoolState();
   const {
     activate: showPauseRuntimeModal,
     deactivate: closePauseRuntimeModal,
@@ -69,10 +68,6 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
 
   const handleClick = () => {
     if (action === RuntimeAction.Start) {
-      if (!selectedCapability) {
-        showErrorModal();
-        return;
-      }
       if (!runtimeRunning) {
         startRuntime(runtime, selectedCapability?.id);
         return;
@@ -93,24 +88,6 @@ const RuntimeRunner = ({ action, runtime, capability, children }: Props) => {
     <div>
       {React.cloneElement(children, { onClick: handleClick })}
       <div>
-        {isErrorModalVisible && (
-          <ModalContainer
-            title="CANNOT START TOOLS"
-            onAccept={closeErrorModal}
-            onCancel={closeErrorModal}
-            actionButtonLabel="Accept"
-            actionButtonCancel="Cancel"
-            className={cx(styles.runtimeModal, styles.close)}
-            error
-            blocking
-          >
-            <ModalLayoutInfo className={styles.runtimeModalInfo}>
-              <div data-testid="errorToolsModal">
-                <p>Please select a capability before starting the User Tools.</p>
-              </div>
-            </ModalLayoutInfo>
-          </ModalContainer>
-        )}
         {isPauseRuntimeModalVisible && (
           <ModalContainer
             title="STOP YOUR TOOLS"

--- a/app/ui/src/Components/SiteBar/SiteBar.tsx
+++ b/app/ui/src/Components/SiteBar/SiteBar.tsx
@@ -18,8 +18,8 @@ const SiteBar = () => (
       </>
     </Left>
     <Right className={styles.right}>
-      <RuntimesCrumb title={"Runtimes"} />
-      <CapabilitiesCrumb title={"Capabilities"} />
+      <RuntimesCrumb title={'Runtimes'} />
+      <CapabilitiesCrumb title={'Capabilities'} />
       <SettingsMenu />
     </Right>
   </div>

--- a/app/ui/src/Components/SiteBar/SiteBar.tsx
+++ b/app/ui/src/Components/SiteBar/SiteBar.tsx
@@ -7,6 +7,7 @@ import SettingsMenu from '../SettingsMenu/SettingsMenu';
 import styles from './SiteBar.module.scss';
 import isElectron from 'is-electron';
 import RuntimesCrumb from './components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb';
+import CapabilitiesCrumb from './components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb';
 
 const SiteBar = () => (
   <div className={styles.container}>
@@ -17,7 +18,8 @@ const SiteBar = () => (
       </>
     </Left>
     <Right className={styles.right}>
-      <RuntimesCrumb />
+      <RuntimesCrumb title={"Runtimes"} />
+      <CapabilitiesCrumb title={"Capabilities"} />
       <SettingsMenu />
     </Right>
   </div>

--- a/app/ui/src/Components/SiteBar/__snapshots__/SiteBar.test.tsx.snap
+++ b/app/ui/src/Components/SiteBar/__snapshots__/SiteBar.test.tsx.snap
@@ -12,7 +12,12 @@ exports[`SiteBar component Component match snapshot 1`] = `
   <ht
     className="right"
   >
-    <RuntimesCrumb />
+    <RuntimesCrumb
+      title="Runtimes"
+    />
+    <CapabilitiesCrumb
+      title="Capabilities"
+    />
     <Memo(SettingsMenu) />
   </ht>
 </div>

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb.tsx
@@ -2,24 +2,25 @@ import * as React from 'react';
 import { useQuery, useReactiveVar } from '@apollo/client';
 import Crumb, { BottomComponentProps } from '../Crumb/Crumb';
 import GetCapabilitiesQuery from 'Graphql/queries/getCapabilities';
-import { lastRanRuntime, loadingRuntime, runningRuntime, selectedCapabilities } from 'Graphql/client/cache';
-import { GetCapabilities, GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
+import { loadingRuntime, runningRuntime, selectedCapabilities } from 'Graphql/client/cache';
+import { GetCapabilities } from 'Graphql/queries/types/GetCapabilities';
 import RuntimeIcon, { RUNTIME_STATUS } from 'Components/Icons/RuntimeIcon/RuntimeIcon';
 import CapabilitiesSelector from 'Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector';
-import getCapabilities from 'Graphql/queries/getCapabilities';
+import { useRouteMatch } from 'react-router-dom';
+import ROUTE from 'Constants/routes';
 
 export type Props = {
   title?: string;
 };
 
 function CapabilitiesCrumb({title }: Props) {
-  const { data, loading, error } = useQuery<GetCapabilities>(GetCapabilitiesQuery);
-  const runtimeLastRan = useReactiveVar(lastRanRuntime);
+  const { data, error } = useQuery<GetCapabilities>(GetCapabilitiesQuery);
+  const isProjectRoute = useRouteMatch(ROUTE.PROJECT);
   const selectedCapability = useReactiveVar(selectedCapabilities);
   const runtimeRunning = useReactiveVar(runningRuntime)
   const runtimeLoading = useReactiveVar(loadingRuntime);
 
-  if (!data) return null;
+  if (!data || !isProjectRoute) return null;
   if (error) throw Error('cannot retrieve data at CapabilitiesCrumb');
 
   const executionStatus = runtimeRunning ? RUNTIME_STATUS.RUNNING : RUNTIME_STATUS.STOPPED;

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useQuery, useReactiveVar } from '@apollo/client';
+import Crumb, { BottomComponentProps } from '../Crumb/Crumb';
+import GetCapabilitiesQuery from 'Graphql/queries/getCapabilities';
+import { lastRanRuntime, loadingRuntime, runningRuntime, selectedCapabilities } from 'Graphql/client/cache';
+import { GetCapabilities, GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
+import RuntimeIcon, { RUNTIME_STATUS } from 'Components/Icons/RuntimeIcon/RuntimeIcon';
+import CapabilitiesSelector from 'Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector';
+import getCapabilities from 'Graphql/queries/getCapabilities';
+
+export type Props = {
+  title?: string;
+};
+
+function CapabilitiesCrumb({title }: Props) {
+  const { data, loading, error } = useQuery<GetCapabilities>(GetCapabilitiesQuery);
+  const runtimeLastRan = useReactiveVar(lastRanRuntime);
+  const selectedCapability = useReactiveVar(selectedCapabilities);
+  const runtimeRunning = useReactiveVar(runningRuntime)
+  const runtimeLoading = useReactiveVar(loadingRuntime);
+
+  if (!data) return null;
+  if (error) throw Error('cannot retrieve data at CapabilitiesCrumb');
+
+  const executionStatus = runtimeRunning ? RUNTIME_STATUS.RUNNING : RUNTIME_STATUS.STOPPED;
+
+  const runtimeStatus = runtimeLoading !== null ? RUNTIME_STATUS.LOADING : executionStatus;
+
+  return (
+    <Crumb
+      crumbText={selectedCapability? selectedCapability.name : ""}
+      isSelect={true}
+      LeftIconComponent={<RuntimeIcon className="icon-regular" status={runtimeStatus} />}
+      dataTestId="capabilitiesCrumb"
+      title={title}
+      show={data.capabilities.length > 1}
+    >
+      {(props: BottomComponentProps) => <CapabilitiesSelector capabilities={data.capabilities} {...props} />}
+    </Crumb>
+  );
+}
+
+export default CapabilitiesCrumb;

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/CapabilitiesCrumbs/CapabilitiesCrumb.tsx
@@ -13,11 +13,11 @@ export type Props = {
   title?: string;
 };
 
-function CapabilitiesCrumb({title }: Props) {
+function CapabilitiesCrumb({ title }: Props) {
   const { data, error } = useQuery<GetCapabilities>(GetCapabilitiesQuery);
   const isProjectRoute = useRouteMatch(ROUTE.PROJECT);
   const selectedCapability = useReactiveVar(selectedCapabilities);
-  const runtimeRunning = useReactiveVar(runningRuntime)
+  const runtimeRunning = useReactiveVar(runningRuntime);
   const runtimeLoading = useReactiveVar(loadingRuntime);
 
   if (!data || !isProjectRoute) return null;
@@ -29,7 +29,7 @@ function CapabilitiesCrumb({title }: Props) {
 
   return (
     <Crumb
-      crumbText={selectedCapability? selectedCapability.name : ""}
+      crumbText={selectedCapability ? selectedCapability.name : ''}
       isSelect={true}
       LeftIconComponent={<RuntimeIcon className="icon-regular" status={runtimeStatus} />}
       dataTestId="capabilitiesCrumb"

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.module.scss
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.module.scss
@@ -5,6 +5,7 @@
 .container {
   position: relative;
   display: flex;
+  flex-direction: row;
   align-items: center;
   height: 100%;
   cursor: pointer;
@@ -13,6 +14,25 @@
 
   &:not(&.select):hover {
     background-color: palette(base, 400);
+  }
+
+
+  &.hidden {
+    display: none;
+  }
+
+  .crumbTitle {
+    color: font-color(light);
+    font-size: small;
+    margin-right: 5px;
+  }
+
+  .crumbTitle2 {
+    position: absolute;
+    margin-bottom: 3 * $grid-unit;
+    color: palette(highlight);
+    font-size: smaller;
+    font-weight: bold;
   }
 
   .crumbContainer {

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.module.scss
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.module.scss
@@ -27,14 +27,6 @@
     margin-right: 5px;
   }
 
-  .crumbTitle2 {
-    position: absolute;
-    margin-bottom: 3 * $grid-unit;
-    color: palette(highlight);
-    font-size: smaller;
-    font-weight: bold;
-  }
-
   .crumbContainer {
     display: flex;
     align-items: center;

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './Crumb.module.scss';
 import cx from 'classnames';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import useBoolState from 'Hooks/useBoolState';
 import { ExpandableMenu } from 'kwc';
-import { relative } from 'path';
 
 export interface BottomComponentProps {
   closeComponent: () => void;
@@ -19,11 +18,14 @@ export type CrumbProps = {
   show?: boolean;
 };
 
-function Crumb({ crumbText, LeftIconComponent, dataTestId, children, title, isSelect, show =  true }: CrumbProps) {
+function Crumb({ crumbText, LeftIconComponent, dataTestId, children, title, isSelect, show = true }: CrumbProps) {
   const { value: opened, toggle: toggleComponent, deactivate: hideComponent } = useBoolState(false);
 
   return (
-    <div className={cx(styles.container, { [styles.select]: isSelect, [styles.hidden]: !show })} data-testid={dataTestId}>
+    <div
+      className={cx(styles.container, { [styles.select]: isSelect, [styles.hidden]: !show })}
+      data-testid={dataTestId}
+    >
       {title && <span className={styles.crumbTitle2}>{title}</span>}
       <div className={cx(styles.crumbContainer, { [styles.select]: isSelect })} onClick={toggleComponent}>
         {LeftIconComponent}

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.tsx
@@ -26,7 +26,7 @@ function Crumb({ crumbText, LeftIconComponent, dataTestId, children, title, isSe
       className={cx(styles.container, { [styles.select]: isSelect, [styles.hidden]: !show })}
       data-testid={dataTestId}
     >
-      {title && <span className={styles.crumbTitle2}>{title}</span>}
+      {title && <span className={styles.crumbTitle}>{title}</span>}
       <div className={cx(styles.crumbContainer, { [styles.select]: isSelect })} onClick={toggleComponent}>
         {LeftIconComponent}
         <span className={styles.crumbText}>{crumbText}</span>

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/Crumb/Crumb.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import useBoolState from 'Hooks/useBoolState';
 import { ExpandableMenu } from 'kwc';
+import { relative } from 'path';
 
 export interface BottomComponentProps {
   closeComponent: () => void;
@@ -13,14 +14,17 @@ export type CrumbProps = {
   crumbText: string;
   LeftIconComponent: React.ReactElement;
   children: (props: BottomComponentProps) => JSX.Element;
+  title?: string;
   isSelect?: boolean;
+  show?: boolean;
 };
 
-function Crumb({ crumbText, LeftIconComponent, dataTestId, children, isSelect }: CrumbProps) {
+function Crumb({ crumbText, LeftIconComponent, dataTestId, children, title, isSelect, show =  true }: CrumbProps) {
   const { value: opened, toggle: toggleComponent, deactivate: hideComponent } = useBoolState(false);
 
   return (
-    <div className={cx(styles.container, { [styles.select]: isSelect })} data-testid={dataTestId}>
+    <div className={cx(styles.container, { [styles.select]: isSelect, [styles.hidden]: !show })} data-testid={dataTestId}>
+      {title && <span className={styles.crumbTitle2}>{title}</span>}
       <div className={cx(styles.crumbContainer, { [styles.select]: isSelect })} onClick={toggleComponent}>
         {LeftIconComponent}
         <span className={styles.crumbText}>{crumbText}</span>

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb.tsx
@@ -7,7 +7,11 @@ import { GetRuntimes } from 'Graphql/queries/types/GetRuntimes';
 import RuntimeSelector from 'Components/SiteBar/components/RuntimeSelector/RuntimeSelector';
 import RuntimeIcon, { RUNTIME_STATUS } from 'Components/Icons/RuntimeIcon/RuntimeIcon';
 
-function RuntimesCrumb() {
+export type Props = {
+  title?: string;
+};
+
+function RuntimesCrumb({title }: Props) {
   const { data, loading, error } = useQuery<GetRuntimes>(GetRuntimesQuery);
   const runtimeLastRan = useReactiveVar(lastRanRuntime);
   const runtimeRunning = useReactiveVar(runningRuntime);
@@ -26,6 +30,7 @@ function RuntimesCrumb() {
       isSelect={true}
       LeftIconComponent={<RuntimeIcon className="icon-regular" status={runtimeStatus} />}
       dataTestId="runtimesCrumb"
+      title={title}
     >
       {(props: BottomComponentProps) => <RuntimeSelector runtimes={data.runtimes} {...props} />}
     </Crumb>

--- a/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb.tsx
+++ b/app/ui/src/Components/SiteBar/components/Breadcrumbs/components/RuntimesCrumbs/RuntimesCrumb.tsx
@@ -11,7 +11,7 @@ export type Props = {
   title?: string;
 };
 
-function RuntimesCrumb({title }: Props) {
+function RuntimesCrumb({ title }: Props) {
   const { data, loading, error } = useQuery<GetRuntimes>(GetRuntimesQuery);
   const runtimeLastRan = useReactiveVar(lastRanRuntime);
   const runtimeRunning = useReactiveVar(runningRuntime);

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.module.scss
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.module.scss
@@ -1,0 +1,50 @@
+@import 'Styles/variables';
+@import 'Styles/mixins';
+@import 'Styles/colors';
+@import 'Styles/shadows';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  background-color: palette(base);
+  padding: $grid-unit;
+  @include font-small;
+  color: font-color(lowlight);
+  width: 100%;
+  transition:
+    background-color ease 0.3s,
+    color ease 0.2s, opacity ease 0.3s;
+
+  &:hover {
+    background-color: palette(base, 300);
+  }
+
+  .nameContainer {
+    margin-left: $grid-unit;
+    display: flex;
+
+    .name {
+      display: flex;
+      margin-left: $grid-unit;
+    }
+  }
+
+  .labels {
+    display: flex;
+    flex-wrap: wrap;
+    row-gap: 0.5 * $grid-unit;
+    margin-top: 1.1 * $grid-unit;
+    margin-left: 4 * $grid-unit;
+
+    .label {
+      position: relative;
+      float: left;
+      margin: 0 1.5 * $grid-unit 0 0;
+      padding: 0.4 * $grid-unit 1.5 * $grid-unit;
+      background-color: palette(tag);
+      border-radius: 0.5 * $grid-unit;
+      @include font-small;
+      color: font-color(regular);
+    }
+  }
+}

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.tsx
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.tsx
@@ -16,18 +16,19 @@ function CapabilitiesItem({ capability }: Props) {
   const isCapabilitySelected = selectedCapability?.id === capability.id;
 
   const getRuntimeStatus = () => {
-
-    // TODO change enum
     if (isCapabilitySelected) return RUNTIME_STATUS.RUNNING;
     return RUNTIME_STATUS.NOT_SELECTED;
   };
 
   return (
-    <RuntimeRunner runtime={runtimeRunning?runtimeRunning : undefined} capability={capability} action={RuntimeAction.Start}>
+    <RuntimeRunner
+      runtime={runtimeRunning ? runtimeRunning : undefined}
+      capability={capability}
+      action={RuntimeAction.ReplaceCapability}>
       <button className={styles.container} disabled={isCapabilitySelected}>
         <div className={styles.nameContainer}>
           <RuntimeIcon status={getRuntimeStatus()} className="icon-regular" />
-          <div className={styles.name}>{capability.name} - { capability.default? "True" : "False" }</div>
+          <div className={styles.name}>{capability.name}</div>
         </div>
       </button>
     </RuntimeRunner>

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.tsx
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 function CapabilitiesItem({ capability }: Props) {
   const selectedCapability = useReactiveVar(selectedCapabilities);
-  const runtimeRunning = useReactiveVar(runningRuntime)
+  const runtimeRunning = useReactiveVar(runningRuntime);
   const isCapabilitySelected = selectedCapability?.id === capability.id;
 
   const getRuntimeStatus = () => {
@@ -24,7 +24,8 @@ function CapabilitiesItem({ capability }: Props) {
     <RuntimeRunner
       runtime={runtimeRunning ? runtimeRunning : undefined}
       capability={capability}
-      action={RuntimeAction.ReplaceCapability}>
+      action={RuntimeAction.ReplaceCapability}
+    >
       <button className={styles.container} disabled={isCapabilitySelected}>
         <div className={styles.nameContainer}>
           <RuntimeIcon status={getRuntimeStatus()} className="icon-regular" />

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.tsx
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesItem/CapabilitiesItem.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styles from './CapabilitiesItem.module.scss';
+import RuntimeIcon, { RUNTIME_STATUS } from 'Components/Icons/RuntimeIcon/RuntimeIcon';
+import { useReactiveVar } from '@apollo/client';
+import { runningRuntime, selectedCapabilities } from 'Graphql/client/cache';
+import RuntimeRunner, { RuntimeAction } from 'Components/RuntimeRunner/RuntimeRunner';
+import { GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
+
+type Props = {
+  capability: GetCapabilities_capabilities;
+};
+
+function CapabilitiesItem({ capability }: Props) {
+  const selectedCapability = useReactiveVar(selectedCapabilities);
+  const runtimeRunning = useReactiveVar(runningRuntime)
+  const isCapabilitySelected = selectedCapability?.id === capability.id;
+
+  const getRuntimeStatus = () => {
+
+    // TODO change enum
+    if (isCapabilitySelected) return RUNTIME_STATUS.RUNNING;
+    return RUNTIME_STATUS.NOT_SELECTED;
+  };
+
+  return (
+    <RuntimeRunner runtime={runtimeRunning?runtimeRunning : undefined} capability={capability} action={RuntimeAction.Start}>
+      <button className={styles.container} disabled={isCapabilitySelected}>
+        <div className={styles.nameContainer}>
+          <RuntimeIcon status={getRuntimeStatus()} className="icon-regular" />
+          <div className={styles.name}>{capability.name} - { capability.default? "True" : "False" }</div>
+        </div>
+      </button>
+    </RuntimeRunner>
+  );
+}
+
+export default CapabilitiesItem;

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.module.scss
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.module.scss
@@ -1,0 +1,21 @@
+@import 'Styles/variables';
+@import 'Styles/mixins';
+@import 'Styles/colors';
+@import 'Styles/shadows';
+
+$shape-height: 65 * $grid-unit;
+
+.container {
+  @include shadow(2);
+  overflow: auto;
+  width: 40 * $grid-unit;
+  max-height: $shape-height;
+  min-height: 100%;
+
+  ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    background-color: palette(lowlight, 900);
+  }
+}

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.tsx
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react';
+import styles from './CapabilitiesSelector.module.scss';
+import { useReactiveVar } from '@apollo/client';
+import { selectedCapabilities } from 'Graphql/client/cache';
+import { BottomComponentProps } from '../Breadcrumbs/components/Crumb/Crumb';
+import { GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
+import CapabilitiesItem from './CapabilitiesItem/CapabilitiesItem';
+
+type Props = {
+  capabilities: GetCapabilities_capabilities[] | undefined;
+};
+
+function sortCapability(capability1: GetCapabilities_capabilities, capability2: GetCapabilities_capabilities, selectedCapabilityId: string | null) {
+  /*if (selectedCapabilityId) {
+    return capability1.id === selectedCapabilityId ? 2 : capability1.default ? 1 : -1;
+  }*/
+
+  return capability1.default? 1 : -1;
+}
+
+
+const CapabilitiesSelector: FC<Props & BottomComponentProps> = ({ capabilities, ...props }) => {
+  const selectedCapability = useReactiveVar(selectedCapabilities);
+
+  return (
+    <div className={styles.container}>
+      <ul>
+        {capabilities?.slice()
+          .sort((a: GetCapabilities_capabilities, b: GetCapabilities_capabilities) => sortCapability(a, b, selectedCapability ? selectedCapability.id : null))
+          .reverse()
+          .map((capability: GetCapabilities_capabilities) => (
+            <li key={capability.id}>
+              <CapabilitiesItem capability={capability} {...props} />
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  )
+};
+export default CapabilitiesSelector;

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.tsx
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.tsx
@@ -11,10 +11,6 @@ type Props = {
 };
 
 function sortCapability(capability1: GetCapabilities_capabilities, capability2: GetCapabilities_capabilities, selectedCapabilityId: string | null) {
-  /*if (selectedCapabilityId) {
-    return capability1.id === selectedCapabilityId ? 2 : capability1.default ? 1 : -1;
-  }*/
-
   return capability1.default? 1 : -1;
 }
 

--- a/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.tsx
+++ b/app/ui/src/Components/SiteBar/components/CapabilitiesSelector/CapabilitiesSelector.tsx
@@ -10,10 +10,13 @@ type Props = {
   capabilities: GetCapabilities_capabilities[] | undefined;
 };
 
-function sortCapability(capability1: GetCapabilities_capabilities, capability2: GetCapabilities_capabilities, selectedCapabilityId: string | null) {
-  return capability1.default? 1 : -1;
+function sortCapability(
+  capability1: GetCapabilities_capabilities,
+  capability2: GetCapabilities_capabilities,
+  selectedCapabilityId: string | null,
+) {
+  return capability1.default ? 1 : -1;
 }
-
 
 const CapabilitiesSelector: FC<Props & BottomComponentProps> = ({ capabilities, ...props }) => {
   const selectedCapability = useReactiveVar(selectedCapabilities);
@@ -21,17 +24,19 @@ const CapabilitiesSelector: FC<Props & BottomComponentProps> = ({ capabilities, 
   return (
     <div className={styles.container}>
       <ul>
-        {capabilities?.slice()
-          .sort((a: GetCapabilities_capabilities, b: GetCapabilities_capabilities) => sortCapability(a, b, selectedCapability ? selectedCapability.id : null))
+        {capabilities
+          ?.slice()
+          .sort((a: GetCapabilities_capabilities, b: GetCapabilities_capabilities) =>
+            sortCapability(a, b, selectedCapability ? selectedCapability.id : null),
+          )
           .reverse()
           .map((capability: GetCapabilities_capabilities) => (
             <li key={capability.id}>
               <CapabilitiesItem capability={capability} {...props} />
             </li>
-          ))
-        }
+          ))}
       </ul>
     </div>
-  )
+  );
 };
 export default CapabilitiesSelector;

--- a/app/ui/src/Components/SiteBar/components/RuntimeSelector/RuntimeItem/RuntimeItem.tsx
+++ b/app/ui/src/Components/SiteBar/components/RuntimeSelector/RuntimeItem/RuntimeItem.tsx
@@ -32,7 +32,8 @@ function RuntimeItem({ runtime }: Props) {
     <RuntimeRunner
       runtime={runtime}
       capability={selectedCapability ? selectedCapability : undefined}
-      action={RuntimeAction.Start}>
+      action={RuntimeAction.Start}
+    >
       <button className={styles.container} disabled={runtimeLoading !== null || isRuntimeRunning}>
         <div className={styles.nameContainer}>
           <RuntimeIcon status={getRuntimeStatus()} className="icon-regular" />

--- a/app/ui/src/Components/SiteBar/components/RuntimeSelector/RuntimeItem/RuntimeItem.tsx
+++ b/app/ui/src/Components/SiteBar/components/RuntimeSelector/RuntimeItem/RuntimeItem.tsx
@@ -29,7 +29,10 @@ function RuntimeItem({ runtime }: Props) {
   };
 
   return (
-    <RuntimeRunner runtime={runtime} capability={selectedCapability? selectedCapability : undefined} action={RuntimeAction.Start}>
+    <RuntimeRunner
+      runtime={runtime}
+      capability={selectedCapability ? selectedCapability : undefined}
+      action={RuntimeAction.Start}>
       <button className={styles.container} disabled={runtimeLoading !== null || isRuntimeRunning}>
         <div className={styles.nameContainer}>
           <RuntimeIcon status={getRuntimeStatus()} className="icon-regular" />

--- a/app/ui/src/Components/SiteBar/components/RuntimeSelector/RuntimeItem/RuntimeItem.tsx
+++ b/app/ui/src/Components/SiteBar/components/RuntimeSelector/RuntimeItem/RuntimeItem.tsx
@@ -3,7 +3,7 @@ import styles from './RuntimeItem.module.scss';
 import { GetRuntimes_runtimes } from 'Graphql/queries/types/GetRuntimes';
 import RuntimeIcon, { RUNTIME_STATUS } from 'Components/Icons/RuntimeIcon/RuntimeIcon';
 import { useReactiveVar } from '@apollo/client';
-import { lastRanRuntime, loadingRuntime, runningRuntime } from 'Graphql/client/cache';
+import { lastRanRuntime, loadingRuntime, runningRuntime, selectedCapabilities } from 'Graphql/client/cache';
 import RuntimeRunner, { RuntimeAction } from 'Components/RuntimeRunner/RuntimeRunner';
 
 type Props = {
@@ -14,6 +14,7 @@ function RuntimeItem({ runtime }: Props) {
   const runtimeRunning = useReactiveVar(runningRuntime);
   const runtimeLoading = useReactiveVar(loadingRuntime);
   const lastRuntime = useReactiveVar(lastRanRuntime);
+  const selectedCapability = useReactiveVar(selectedCapabilities);
   const isRuntimeRunning = runtimeRunning?.id === runtime.id;
 
   const getRuntimeStatus = () => {
@@ -28,7 +29,7 @@ function RuntimeItem({ runtime }: Props) {
   };
 
   return (
-    <RuntimeRunner runtime={runtime} action={RuntimeAction.Start}>
+    <RuntimeRunner runtime={runtime} capability={selectedCapability? selectedCapability : undefined} action={RuntimeAction.Start}>
       <button className={styles.container} disabled={runtimeLoading !== null || isRuntimeRunning}>
         <div className={styles.nameContainer}>
           <RuntimeIcon status={getRuntimeStatus()} className="icon-regular" />

--- a/app/ui/src/Graphql/client/cache.tsx
+++ b/app/ui/src/Graphql/client/cache.tsx
@@ -9,6 +9,7 @@ import { NewProject } from './models/NewProject';
 import { PanelInfo } from './models/Panel';
 import { SettingsTab } from './models/SettingsTab';
 import { GetRuntimes_runtimes } from '../queries/types/GetRuntimes';
+import { GetCapabilities_capabilities } from '../queries/types/GetCapabilities';
 
 type ToolName = keyof GetUserTools_project_toolUrls;
 
@@ -74,6 +75,8 @@ export const lastRanRuntime = makeVar<GetRuntimes_runtimes | null>(null);
 // the actual running runtime
 export const runningRuntime = makeVar<GetRuntimes_runtimes | null>(null);
 export const loadingRuntime = makeVar<string | null>(null);
+export const selectedCapabilities = makeVar<GetCapabilities_capabilities | null>(null);
+export const lastSelectedCapability = makeVar<GetCapabilities_capabilities | null>(null);
 
 const cache = new InMemoryCache({
   typePolicies: {

--- a/app/ui/src/Graphql/client/cache.tsx
+++ b/app/ui/src/Graphql/client/cache.tsx
@@ -76,7 +76,6 @@ export const lastRanRuntime = makeVar<GetRuntimes_runtimes | null>(null);
 export const runningRuntime = makeVar<GetRuntimes_runtimes | null>(null);
 export const loadingRuntime = makeVar<string | null>(null);
 export const selectedCapabilities = makeVar<GetCapabilities_capabilities | null>(null);
-export const lastSelectedCapability = makeVar<GetCapabilities_capabilities | null>(null);
 
 const cache = new InMemoryCache({
   typePolicies: {

--- a/app/ui/src/Graphql/client/hooks/useCapabilities.ts
+++ b/app/ui/src/Graphql/client/hooks/useCapabilities.ts
@@ -1,0 +1,12 @@
+import { GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
+import { selectedCapabilities } from '../cache';
+
+function useCapabilities() {
+  function setRunningCapabilities(selectedCapability: GetCapabilities_capabilities | null) {
+    selectedCapabilities(selectedCapability);
+  }
+
+  return { setRunningCapabilities };
+}
+
+export default useCapabilities;

--- a/app/ui/src/Graphql/client/hooks/useRuntime.ts
+++ b/app/ui/src/Graphql/client/hooks/useRuntime.ts
@@ -38,14 +38,16 @@ function useRuntime(runtime?: GetRuntimes_runtimes) {
     runningRuntime(null);
   }
 
-  async function startRuntime(runtime?: GetRuntimes_runtimes) {
+  async function startRuntime(runtime?: GetRuntimes_runtimes, capabilitiesId?: string | null) {
     if (!runtime) {
       openRuntimesList();
       return;
     }
     const areToolsActive = true;
     setRuntimeLoading(runtime.id ?? '');
-    mutationSetActiveProjectTools(mutationPayloadHelper({ active: areToolsActive, runtimeId: runtime.id }));
+    mutationSetActiveProjectTools(
+      mutationPayloadHelper({ active: areToolsActive, runtimeId: runtime.id, capabilitiesId: capabilitiesId }),
+    );
   }
 
   function pauseRuntime() {

--- a/app/ui/src/Graphql/queries/getCapabilities.ts
+++ b/app/ui/src/Graphql/queries/getCapabilities.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  query GetCapabilities {
+    capabilities {
+      id
+      name
+      default
+    }
+  }
+`;

--- a/app/ui/src/Graphql/queries/getRunningCapabilities.ts
+++ b/app/ui/src/Graphql/queries/getRunningCapabilities.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  query GetRunningCapabilities {
+    runningCapability {
+      id
+      name
+      default
+    }
+  }
+`;

--- a/app/ui/src/Graphql/queries/types/GetCapabilities.ts
+++ b/app/ui/src/Graphql/queries/types/GetCapabilities.ts
@@ -1,0 +1,19 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetCapabilities
+// ====================================================
+
+export interface GetCapabilities_capabilities {
+  __typename: "Capability";
+  id: string;
+  name: string;
+  default: boolean;
+}
+
+export interface GetCapabilities {
+  capabilities: GetCapabilities_capabilities[];
+}

--- a/app/ui/src/Graphql/queries/types/GetRunningCapabilities.ts
+++ b/app/ui/src/Graphql/queries/types/GetRunningCapabilities.ts
@@ -1,0 +1,19 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetRunningCapabilities
+// ====================================================
+
+export interface GetRunningCapabilities_runningCapability {
+  __typename: "Capability";
+  id: string;
+  name: string;
+  default: boolean;
+}
+
+export interface GetRunningCapabilities {
+  runningCapability: GetRunningCapabilities_runningCapability | null;
+}

--- a/app/ui/src/Graphql/types/globalTypes.ts
+++ b/app/ui/src/Graphql/types/globalTypes.ts
@@ -64,6 +64,7 @@ export interface RepositoryInput {
 export interface SetActiveUserToolsInput {
   active: boolean;
   runtimeId?: string | null;
+  capabilitiesId?: string | null;
 }
 
 export interface UpdateAccessLevelInput {

--- a/app/ui/src/Mocks/GetCapabilitiesQuery.ts
+++ b/app/ui/src/Mocks/GetCapabilitiesQuery.ts
@@ -1,0 +1,5 @@
+import { capability, capability2 } from './entities/capabilities';
+
+export default {
+  capabilities: [capability, capability2],
+};

--- a/app/ui/src/Mocks/GetRunningCapabilities2Query.ts
+++ b/app/ui/src/Mocks/GetRunningCapabilities2Query.ts
@@ -1,0 +1,5 @@
+import { capability2 } from './entities/capabilities';
+
+export default {
+  runningCapability: capability2,
+};

--- a/app/ui/src/Mocks/GetRunningCapabilitiesQuery.ts
+++ b/app/ui/src/Mocks/GetRunningCapabilitiesQuery.ts
@@ -1,0 +1,5 @@
+import { capability } from './entities/capabilities';
+
+export default {
+  runningCapability: capability,
+};

--- a/app/ui/src/Mocks/GetSingleCapabilityQuery.ts
+++ b/app/ui/src/Mocks/GetSingleCapabilityQuery.ts
@@ -1,0 +1,5 @@
+import { capability, capability2 } from './entities/capabilities';
+
+export default {
+  capabilities: [capability],
+};

--- a/app/ui/src/Mocks/GetSingleCapabilityQuery.ts
+++ b/app/ui/src/Mocks/GetSingleCapabilityQuery.ts
@@ -1,4 +1,4 @@
-import { capability, capability2 } from './entities/capabilities';
+import { capability } from './entities/capabilities';
 
 export default {
   capabilities: [capability],

--- a/app/ui/src/Mocks/entities/capabilities.ts
+++ b/app/ui/src/Mocks/entities/capabilities.ts
@@ -1,5 +1,4 @@
 import { GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
-import { GetRunningRuntime_runningRuntime } from '../../Graphql/queries/types/GetRunningRuntime';
 
 export const capability: GetCapabilities_capabilities = {
   __typename: 'Capability',

--- a/app/ui/src/Mocks/entities/capabilities.ts
+++ b/app/ui/src/Mocks/entities/capabilities.ts
@@ -1,0 +1,16 @@
+import { GetCapabilities_capabilities } from 'Graphql/queries/types/GetCapabilities';
+import { GetRunningRuntime_runningRuntime } from '../../Graphql/queries/types/GetRunningRuntime';
+
+export const capability: GetCapabilities_capabilities = {
+  __typename: 'Capability',
+  id: 'capability1',
+  name: 'Capability Name 1',
+  default: false,
+};
+
+export const capability2: GetCapabilities_capabilities = {
+  __typename: 'Capability',
+  id: 'capability2',
+  name: 'Capability Name 2',
+  default: true,
+};

--- a/app/ui/src/Mocks/entities/capabilities.ts
+++ b/app/ui/src/Mocks/entities/capabilities.ts
@@ -13,3 +13,10 @@ export const capability2: GetCapabilities_capabilities = {
   name: 'Capability Name 2',
   default: true,
 };
+
+export const capability3: GetCapabilities_capabilities = {
+  __typename: 'Capability',
+  id: 'capability3',
+  name: 'Capability Name 3',
+  default: true,
+};

--- a/app/ui/src/Pages/Project/Project.tsx
+++ b/app/ui/src/Pages/Project/Project.tsx
@@ -18,9 +18,14 @@ import useOpenedProject from 'Graphql/client/hooks/useOpenedProject';
 import { GetProjects } from 'Graphql/queries/types/GetProjects';
 import GetProjectsQuery from 'Graphql/queries/getProjects';
 import useRuntime from 'Graphql/client/hooks/useRuntime';
+import useCapabilities from 'Graphql/client/hooks/useCapabilities';
 import { GetRunningRuntime } from 'Graphql/queries/types/GetRunningRuntime';
 import GetRunningRuntimeQuery from 'Graphql/queries/getRunningRuntime';
 import useRuntimeLoading from 'Graphql/client/hooks/useRuntimeLoading';
+import { GetRunningCapabilities } from 'Graphql/queries/types/GetRunningCapabilities';
+import GetRunningCapabilitiesQuery from 'Graphql/queries/getRunningCapabilities';
+import { GetCapabilities } from 'Graphql/queries/types/GetCapabilities';
+import GetCapabilitiesQuery from 'Graphql/queries/getCapabilities';
 
 function Project() {
   const { projectId } = useParams<RouteProjectParams>();
@@ -33,8 +38,11 @@ function Project() {
   const { updateOpenedProject } = useOpenedProject();
   const { resetTools } = useTools();
   const { updateRunningRuntime } = useRuntime();
+  const { setRunningCapabilities } = useCapabilities();
 
   const { data: dataRuntimeRunning, loading: runtimeLoading } = useQuery<GetRunningRuntime>(GetRunningRuntimeQuery);
+  const { data: dataCapabilitiesRunning } = useQuery<GetRunningCapabilities>(GetRunningCapabilitiesQuery);
+  const { data: dataCapabilities } = useQuery<GetCapabilities>(GetCapabilitiesQuery);
   const { setRuntimeLoading } = useRuntimeLoading();
 
   useEffect(() => {
@@ -53,6 +61,25 @@ function Project() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataRuntimeRunning, runtimeLoading]);
+
+  useEffect(() => {
+    if (dataCapabilitiesRunning?.runningCapability) {
+      setRunningCapabilities(dataCapabilitiesRunning.runningCapability);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataCapabilitiesRunning]);
+
+   useEffect(() => {
+     if (!dataCapabilitiesRunning?.runningCapability && dataCapabilities?.capabilities) {
+       setRunningCapabilities(
+         dataCapabilities.capabilities
+          .slice()
+          .sort((a,b) => a.default? 1 : -1)
+          .reverse()[0]
+       );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataCapabilities]);
 
   useEffect(
     () => () => {

--- a/app/ui/src/Pages/Project/Project.tsx
+++ b/app/ui/src/Pages/Project/Project.tsx
@@ -69,14 +69,14 @@ function Project() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataCapabilitiesRunning]);
 
-   useEffect(() => {
-     if (!dataCapabilitiesRunning?.runningCapability && dataCapabilities?.capabilities) {
-       setRunningCapabilities(
-         dataCapabilities.capabilities
+  useEffect(() => {
+    if (!dataCapabilitiesRunning?.runningCapability && dataCapabilities?.capabilities) {
+      setRunningCapabilities(
+        dataCapabilities.capabilities
           .slice()
-          .sort((a,b) => a.default? 1 : -1)
-          .reverse()[0]
-       );
+          .sort((a, b) => (a.default ? 1 : -1))
+          .reverse()[0],
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataCapabilities]);

--- a/app/ui/src/Pages/Project/ProjectPanels.tsx
+++ b/app/ui/src/Pages/Project/ProjectPanels.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect } from 'react';
 import { useReactiveVar } from '@apollo/client';
-import { loadingRuntime, memberDetails, primaryPanel, runningRuntime, secondaryPanel, selectedCapabilities } from 'Graphql/client/cache';
+import {
+  loadingRuntime,
+  memberDetails,
+  primaryPanel,
+  runningRuntime,
+  secondaryPanel,
+  selectedCapabilities,
+} from 'Graphql/client/cache';
 import usePanel, { PanelType } from 'Graphql/client/hooks/usePanel';
 import useMemberDetails from 'Graphql/client/hooks/useMemberDetails';
 import { PANEL_ID } from 'Graphql/client/models/Panel';
@@ -31,7 +38,7 @@ function ProjectPanels({ openedProject }: Props) {
 
   const memberDetailsData = useReactiveVar(memberDetails);
   const runtimeRunning = useReactiveVar(runningRuntime);
-  const selectedCapability = useReactiveVar(selectedCapabilities)
+  const selectedCapability = useReactiveVar(selectedCapabilities);
   const runtimeLoading = useReactiveVar(loadingRuntime);
 
   const selectedRuntime = panel2Data?.runtime ?? null;
@@ -81,7 +88,11 @@ function ProjectPanels({ openedProject }: Props) {
       const startButton = (
         <Tooltip tooltipId="startPanel" spanText="Start tools" tooltipProps={tooltipProps}>
           <div data-tip={true} data-for="startPanel" data-testid="panelStartRuntime">
-            <RuntimeRunner runtime={selectedRuntime ?? undefined} capability={selectedCapability ?? undefined} action={RuntimeAction.Start}>
+            <RuntimeRunner
+              runtime={selectedRuntime ?? undefined}
+              capability={selectedCapability ?? undefined}
+              action={RuntimeAction.Start}
+            >
               <Button label="" Icon={IconPlay} />
             </RuntimeRunner>
           </div>

--- a/app/ui/src/Pages/Project/ProjectPanels.tsx
+++ b/app/ui/src/Pages/Project/ProjectPanels.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useReactiveVar } from '@apollo/client';
-import { loadingRuntime, memberDetails, primaryPanel, runningRuntime, secondaryPanel } from 'Graphql/client/cache';
+import { loadingRuntime, memberDetails, primaryPanel, runningRuntime, secondaryPanel, selectedCapabilities } from 'Graphql/client/cache';
 import usePanel, { PanelType } from 'Graphql/client/hooks/usePanel';
 import useMemberDetails from 'Graphql/client/hooks/useMemberDetails';
 import { PANEL_ID } from 'Graphql/client/models/Panel';
@@ -31,6 +31,7 @@ function ProjectPanels({ openedProject }: Props) {
 
   const memberDetailsData = useReactiveVar(memberDetails);
   const runtimeRunning = useReactiveVar(runningRuntime);
+  const selectedCapability = useReactiveVar(selectedCapabilities)
   const runtimeLoading = useReactiveVar(loadingRuntime);
 
   const selectedRuntime = panel2Data?.runtime ?? null;
@@ -80,7 +81,7 @@ function ProjectPanels({ openedProject }: Props) {
       const startButton = (
         <Tooltip tooltipId="startPanel" spanText="Start tools" tooltipProps={tooltipProps}>
           <div data-tip={true} data-for="startPanel" data-testid="panelStartRuntime">
-            <RuntimeRunner runtime={selectedRuntime ?? undefined} action={RuntimeAction.Start}>
+            <RuntimeRunner runtime={selectedRuntime ?? undefined} capability={selectedCapability ?? undefined} action={RuntimeAction.Start}>
               <Button label="" Icon={IconPlay} />
             </RuntimeRunner>
           </div>

--- a/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.module.scss
+++ b/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.module.scss
@@ -5,6 +5,9 @@
 
 .header {
   padding: 2 * $grid-unit;
+  display: flex;
+  flex-direction: column;
+
   .title {
     margin-bottom: $grid-unit;
 
@@ -15,26 +18,36 @@
       text-align: left;
       @include font-headline;
     }
-    .runningTag {
-      @include font-small;
-      display: inline;
-      position: absolute;
-      margin-left: 2*$grid-unit;
-      justify-self: center;
-      margin-top: 0.75 * $grid-unit;
-      text-align: center;
-      padding: 0.4 * $grid-unit 3.5 * $grid-unit;
-      background-color: palette(success, 700);
-      border-radius: 2 * $grid-unit;
-      color: palette(base);
-      font-weight: bold;
-      max-width: 13 *$grid-unit;
-    }
+  }
+  .runtimeLabels{
+    display: flex;
+    flex-direction: row;
+    margin-bottom: $grid-unit;
 
-    .loadingTag {
-      @extend .runningTag;
-      background-color: palette(feedback);
-    }
+    .runningTag {
+        @include font-small;
+        position: relative;
+        float: left;
+        margin: 0 1.5 * $grid-unit 1.1 * $grid-unit 0;
+        padding: 0.4 * $grid-unit 1.5 * $grid-unit;
+        margin-top: 0.75 * $grid-unit;
+        text-align: center;
+        background-color: palette(success, 700);
+        border-radius: 2 * $grid-unit;
+        color: palette(base);
+        font-weight: bold;
+        width: fit-content
+      }
+
+      .loadingTag {
+        @extend .runningTag;
+        background-color: palette(feedback);
+      }
+
+      .capabilitiesTag {
+        @extend .runningTag;
+        background-color: palette(starred);
+      }
   }
   .runtimeTags {
     display: flex;

--- a/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
@@ -14,7 +14,7 @@ type Props = {
 function RuntimeInfo({ selectedRuntime: runtime, isKubeconfigEnabled }: Props) {
   const activeRuntime = useReactiveVar(runningRuntime);
   const runtimeLoading = useReactiveVar(loadingRuntime);
-  const selectedCapability = useReactiveVar(selectedCapabilities)
+  const selectedCapability = useReactiveVar(selectedCapabilities);
   const running = activeRuntime?.id === runtime.id;
   const runtimeSafeDesc = DOMPurify.sanitize(runtime.desc, { USE_PROFILES: { html: true } });
   const checkReady = () => {

--- a/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
@@ -3,7 +3,7 @@ import { GetRuntimes_runtimes } from 'Graphql/queries/types/GetRuntimes';
 import styles from './RuntimeInfo.module.scss';
 import LabelList from '../RuntimesList/components/LabelList';
 import { useReactiveVar } from '@apollo/client';
-import { loadingRuntime, runningRuntime } from 'Graphql/client/cache';
+import { loadingRuntime, runningRuntime, selectedCapabilities } from 'Graphql/client/cache';
 import DOMPurify from 'dompurify';
 
 type Props = {
@@ -14,6 +14,7 @@ type Props = {
 function RuntimeInfo({ selectedRuntime: runtime, isKubeconfigEnabled }: Props) {
   const activeRuntime = useReactiveVar(runningRuntime);
   const runtimeLoading = useReactiveVar(loadingRuntime);
+  const selectedCapability = useReactiveVar(selectedCapabilities)
   const running = activeRuntime?.id === runtime.id;
   const runtimeSafeDesc = DOMPurify.sanitize(runtime.desc, { USE_PROFILES: { html: true } });
   const checkReady = () => {
@@ -37,7 +38,12 @@ function RuntimeInfo({ selectedRuntime: runtime, isKubeconfigEnabled }: Props) {
         <div data-testid="runtimeInfoPanel">
           <div className={styles.title}>
             <h1 className={styles.headerName}>{runtime.name}</h1>
+          </div>
+          <div className={styles.runtimeLabels}>
             {checkReady()}
+            <div className={styles.capabilitiesTag} data-testid="capabilitiesTag">
+              {selectedCapability?.name}
+            </div>
           </div>
           <div className={styles.runtimeTags}>
             <LabelList runtime={runtime} />

--- a/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimeInfo/RuntimeInfo.tsx
@@ -41,9 +41,11 @@ function RuntimeInfo({ selectedRuntime: runtime, isKubeconfigEnabled }: Props) {
           </div>
           <div className={styles.runtimeLabels}>
             {checkReady()}
-            <div className={styles.capabilitiesTag} data-testid="capabilitiesTag">
-              {selectedCapability?.name}
-            </div>
+            {selectedCapability &&
+              <div className={styles.capabilitiesTag} data-testid="capabilitiesTag">
+                {selectedCapability?.name}
+              </div>
+            }
           </div>
           <div className={styles.runtimeTags}>
             <LabelList runtime={runtime} />

--- a/app/ui/src/Pages/Project/panels/RuntimesList/RuntimeList.module.scss
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/RuntimeList.module.scss
@@ -14,9 +14,15 @@
     padding: 2 * $grid-unit;
   }
   .runtimeContainer {
+    height: 70%;
+  }
+  .capabilitiesContainer {
+    height: 30%;
+  }
+  .runtimeContainer, .capabilitiesContainer {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    //height: 100%;
     background-color: palette(base, 300);
     padding: $grid-unit $grid-unit 7 * $grid-unit $grid-unit;
 

--- a/app/ui/src/Pages/Project/panels/RuntimesList/RuntimeList.module.scss
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/RuntimeList.module.scss
@@ -14,12 +14,9 @@
     padding: 2 * $grid-unit;
   }
   .runtimeContainer {
-    height: 70%;
+    height: 100%;
   }
-  .capabilitiesContainer {
-    height: 30%;
-  }
-  .runtimeContainer, .capabilitiesContainer {
+  .runtimeContainer {
     display: flex;
     flex-direction: column;
     //height: 100%;

--- a/app/ui/src/Pages/Project/panels/RuntimesList/RuntimesList.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/RuntimesList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useQuery, useReactiveVar } from '@apollo/client';
 import GetRuntimesQuery from 'Graphql/queries/getRuntimes';
 import { GetRuntimes, GetRuntimes_runtimes } from 'Graphql/queries/types/GetRuntimes';
@@ -8,10 +8,36 @@ import Runtime from './components/Runtime';
 import { runningRuntime } from 'Graphql/client/cache';
 
 function RuntimesList() {
-  const { data, error } = useQuery<GetRuntimes>(GetRuntimesQuery);
-  const runtimeRunning = useReactiveVar(runningRuntime);
+  try {
+    const runtimeRunning = useReactiveVar(runningRuntime);
+    const runtimes = getRuntimes(runtimeRunning);
 
-  if (error || !data) return <ErrorMessage />;
+    return (
+      <div data-testid="runtimesListPanel" className={styles.runtimesListPanel}>
+        <div className={styles.runtimeListCaption}>
+          Runtimes allows you to personalize the capabilities and libraries version of your user tools.
+        </div>
+        <div className={styles.runtimeContainer}>
+          <div className={styles.runtimeListHeader}>{runtimes.length} RUNTIMES SHOWN</div>
+          <div className={styles.wrapper} data-testid="runtimesList">
+            {[
+              ...runtimes.map((runtime) => (
+                <Runtime key={runtime.id} runtime={runtime} isRunning={runtime.id === runtimeRunning?.id} />
+              )),
+            ]}
+          </div>
+        </div>
+      </div>
+    );
+  } catch {
+    return <ErrorMessage />;
+  }
+}
+
+function getRuntimes(runtimeRunning: GetRuntimes_runtimes | null) {
+  const { data, error } = useQuery<GetRuntimes>(GetRuntimesQuery);
+
+  if (error || !data) throw new Error('Exception loading runtimes');
 
   function sortRuntimes(runtimes: GetRuntimes_runtimes[], runningRuntimeId?: string) {
     if (!runningRuntimeId) {
@@ -22,25 +48,7 @@ function RuntimesList() {
     });
   }
 
-  const runtimes = sortRuntimes(data.runtimes, runtimeRunning?.id);
-
-  return (
-    <div data-testid="runtimesListPanel" className={styles.runtimesListPanel}>
-      <div className={styles.runtimeListCaption}>
-        Runtimes allows you to personalize the capabilities and libraries version of your user tools.
-      </div>
-      <div className={styles.runtimeContainer}>
-        <div className={styles.runtimeListHeader}>{runtimes.length} RUNTIMES SHOWN</div>
-        <div className={styles.wrapper} data-testid="runtimesList">
-          {[
-            ...runtimes.map((runtime) => (
-              <Runtime key={runtime.id} runtime={runtime} isRunning={runtime.id === runtimeRunning?.id} />
-            )),
-          ]}
-        </div>
-      </div>
-    </div>
-  );
+  return sortRuntimes(data.runtimes, runtimeRunning?.id);
 }
 
 export default RuntimesList;

--- a/app/ui/src/Pages/Project/panels/RuntimesList/components/Runtime.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/components/Runtime.tsx
@@ -50,9 +50,9 @@ function Runtime({ runtime, isRunning, disabled }: Props) {
       className={cx(styles.container, {
         [styles.active]: isRunning,
         [styles.loading]: runtimeLoading === runtime.id || (isRunning && runtimeLoading !== null),
-        [styles.disabled]: disabled || selectedCapability === null,
+        [styles.disabled]: disabled,
       })}
-      onClick={() => !disabled && selectedCapability && toggleRuntimePanel()}
+      onClick={() => !disabled && toggleRuntimePanel()}
     >
       <div className={styles.content}>
         <p className={styles.name} data-testid="runtimeName">

--- a/app/ui/src/Pages/Project/panels/RuntimesList/components/Runtime.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/components/Runtime.tsx
@@ -52,7 +52,7 @@ function Runtime({ runtime, isRunning, disabled }: Props) {
         [styles.loading]: runtimeLoading === runtime.id || (isRunning && runtimeLoading !== null),
         [styles.disabled]: disabled || selectedCapability === null,
       })}
-      onClick={() => !disabled && selectedCapability !== null && toggleRuntimePanel()}
+      onClick={() => !disabled && selectedCapability && toggleRuntimePanel()}
     >
       <div className={styles.content}>
         <p className={styles.name} data-testid="runtimeName">

--- a/app/ui/src/Pages/Project/panels/RuntimesList/components/Runtime.tsx
+++ b/app/ui/src/Pages/Project/panels/RuntimesList/components/Runtime.tsx
@@ -6,7 +6,7 @@ import { PANEL_ID } from 'Graphql/client/models/Panel';
 import usePanel, { PanelType } from 'Graphql/client/hooks/usePanel';
 import { PANEL_SIZE, PANEL_THEME } from 'Components/Layout/Panel/Panel';
 import { useReactiveVar } from '@apollo/client';
-import { loadingRuntime } from 'Graphql/client/cache';
+import { loadingRuntime, selectedCapabilities } from 'Graphql/client/cache';
 import LabelList from './LabelList';
 import useRuntimeInfo from 'Hooks/useRuntimeInfo';
 
@@ -17,15 +17,20 @@ type Props = {
 };
 
 function Runtime({ runtime, isRunning, disabled }: Props) {
-  const { openPanel, togglePanel } = usePanel(PanelType.SECONDARY, {
+  const runtimeLoading = useReactiveVar(loadingRuntime);
+  const selectedCapability = useReactiveVar(selectedCapabilities);
+  const [openedRuntimeInfo, setOpenedRuntimeInfo] = useRuntimeInfo();
+  const { openPanel, togglePanel, closePanel } = usePanel(PanelType.SECONDARY, {
     id: PANEL_ID.RUNTIME_INFO,
     title: 'Detail',
     size: PANEL_SIZE.BIG,
     theme: PANEL_THEME.DEFAULT,
     runtime,
   });
-  const runtimeLoading = useReactiveVar(loadingRuntime);
-  const [openedRuntimeInfo, setOpenedRuntimeInfo] = useRuntimeInfo();
+
+  if (selectedCapability === null) {
+    closePanel();
+  }
 
   function toggleRuntimePanel() {
     if (disabled) return;
@@ -45,9 +50,9 @@ function Runtime({ runtime, isRunning, disabled }: Props) {
       className={cx(styles.container, {
         [styles.active]: isRunning,
         [styles.loading]: runtimeLoading === runtime.id || (isRunning && runtimeLoading !== null),
-        [styles.disabled]: disabled,
+        [styles.disabled]: disabled || selectedCapability === null,
       })}
-      onClick={toggleRuntimePanel}
+      onClick={() => !disabled && selectedCapability !== null && toggleRuntimePanel()}
     >
       <div className={styles.content}>
         <p className={styles.name} data-testid="runtimeName">

--- a/app/ui/src/Pages/ProjectCreation/ProjectCreation.tsx
+++ b/app/ui/src/Pages/ProjectCreation/ProjectCreation.tsx
@@ -107,7 +107,7 @@ function ProjectCreation() {
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
-        <h1>Your project is being created now</h1> 
+        <h1>Your project is being created now</h1>
         <div className={styles.animation}>
           <StatusCircle {...getCircleProps()} />
         </div>

--- a/app/ui/src/Pages/ProjectCreation/ProjectCreation.tsx
+++ b/app/ui/src/Pages/ProjectCreation/ProjectCreation.tsx
@@ -107,7 +107,7 @@ function ProjectCreation() {
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
-        <h1>Your project is creating now</h1>
+        <h1>Your project is being created now</h1> 
         <div className={styles.animation}>
           <StatusCircle {...getCircleProps()} />
         </div>

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -3183,9 +3183,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "14.14.28"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"
-  integrity sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
 "@types/node@17.0.42":
   version "17.0.42"
@@ -3193,9 +3193,9 @@
   integrity sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==
 
 "@types/node@^14.14.31":
-  version "14.14.41"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
-  integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
+  version "14.18.33"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
+  integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3330,9 +3330,9 @@
   integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
 "@types/sizzle@^2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
-  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
+  integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -3414,9 +3414,9 @@
   integrity sha512-8NYnGOctzsI4W0ApsP/BIHD/LnxpJ6XaGf2AZmz4EyDYJMxtprN4279dLNI1CPZcwC9H18qYcaFv4bXi0wmokg==
 
 "@types/yauzl@^2.9.1":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.2.tgz#c48e5d56aff1444409e39fa164b0b4d4552a7b7a"
-  integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
   dependencies:
     "@types/node" "*"
 
@@ -3987,21 +3987,28 @@ ansi-colors@^3.0.0:
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
   dependencies:
     type-fest "^0.11.0"
+
+ansi-escapes@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
 
 ansi-html@0.0.7, ansi-html@^0.0.7:
   version "0.0.7"
@@ -4502,16 +4509,16 @@ asn1.js@^5.2.0:
     safer-buffer "^2.1.0"
 
 asn1@~0.2.3:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
-  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
 assert@^1.1.1:
   version "1.5.0"
@@ -4568,12 +4575,12 @@ async@^2.6.2:
 async@^3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
-  integrity "sha1-LSLgD4zd61/eXdM1IrVtHPVpqBw= sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 at-least-node@^1.0.0:
   version "1.0.0"
@@ -4606,7 +4613,7 @@ await-to-js@^2.0.1:
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
 
 aws4@^1.8.0:
   version "1.11.0"
@@ -4822,9 +4829,9 @@ babylon@^6.18.0:
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
@@ -4873,7 +4880,7 @@ batch@0.6.1:
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
   dependencies:
     tweetnacl "^0.14.3"
 
@@ -5121,7 +5128,7 @@ bser@2.1.1:
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -5360,7 +5367,7 @@ case-sensitive-paths-webpack-plugin@2.3.0:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -5391,9 +5398,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -5434,7 +5441,7 @@ charenc@0.0.2:
 check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
-  integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
+  integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
 
 check-types@^11.1.1:
   version "11.1.2"
@@ -5521,10 +5528,10 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
-  integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
+ci-info@^3.2.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.7.0.tgz#6d01b3696c59915b6ce057e4aa4adfc2fa25f5ef"
+  integrity sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -5601,9 +5608,9 @@ cli-progress@^3.4.0:
     string-width "^4.2.0"
 
 cli-table3@~0.6.1:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
-  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
   dependencies:
     string-width "^4.2.0"
   optionalDependencies:
@@ -5734,11 +5741,6 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clone@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 clsx@^1.0.4, clsx@^1.1.0, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
@@ -5827,9 +5829,9 @@ colorette@^1.2.2:
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 colorette@^2.0.16:
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
-  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
 colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
@@ -5868,10 +5870,15 @@ commander@^9.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
   integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
 
-common-tags@^1.5.1, common-tags@^1.8.0:
+common-tags@^1.5.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+
+common-tags@^1.8.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -5913,7 +5920,7 @@ compression@^1.7.4:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 concat-stream@^1.5.0:
   version "1.6.2"
@@ -6513,7 +6520,7 @@ damerau-levenshtein@^1.0.6:
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
   dependencies:
     assert-plus "^1.0.0"
 
@@ -6532,9 +6539,9 @@ date-fns@^1.27.2:
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 dayjs@^1.10.4:
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
-  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.6.tgz#2e79a226314ec3ec904e3ee1dd5a4f5e5b1c7afb"
+  integrity sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
@@ -6550,7 +6557,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.3.4:
+debug@4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -6571,17 +6578,10 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -6701,7 +6701,7 @@ del@^4.1.1:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -6977,7 +6977,7 @@ each-parallel-async@^1.0.0:
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
@@ -7743,9 +7743,9 @@ etag@~1.8.1:
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 eventemitter2@^6.4.3:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.4.tgz#aa96e8275c4dbeb017a5d0e03780c65612a1202b"
-  integrity sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==
+  version "6.4.9"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.9.tgz#41f2750781b4230ed58827bc119d293471ecb125"
+  integrity sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -7956,12 +7956,12 @@ extract-zip@2.0.1:
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
 
 extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -8030,7 +8030,7 @@ fb-watchman@^2.0.0:
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
 
@@ -8239,7 +8239,7 @@ for-in@^1.0.2:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
 fork-ts-checker-webpack-plugin@4.1.6:
   version "4.1.6"
@@ -8359,7 +8359,7 @@ fs-write-stream-atomic@^1.0.8:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@^1.2.7:
   version "1.2.13"
@@ -8516,7 +8516,7 @@ getos@^3.2.1:
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
   dependencies:
     assert-plus "^1.0.0"
 
@@ -8586,7 +8586,7 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -8595,6 +8595,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -8620,9 +8632,9 @@ global-cache@^1.2.1:
     is-symbol "^1.0.1"
 
 global-dirs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
-  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.1.tgz#0c488971f066baceda21447aecb1a8b911d22485"
+  integrity sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==
   dependencies:
     ini "2.0.0"
 
@@ -8740,10 +8752,15 @@ graceful-fs@4.1.15:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 graphql-tag@2.12.4:
   version "2.12.4"
@@ -9364,7 +9381,7 @@ inflected@^2.0.3:
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -9521,11 +9538,11 @@ is-ci@^2.0.0:
     ci-info "^2.0.0"
 
 is-ci@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
-  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
-    ci-info "^3.1.1"
+    ci-info "^3.2.0"
 
 is-color-stop@^1.0.0:
   version "1.1.0"
@@ -9839,9 +9856,9 @@ is-stream@^1.1.0:
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
-  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.5:
   version "1.0.5"
@@ -9882,7 +9899,12 @@ is-touch-device@^1.0.1:
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-weakref@^1.0.1:
   version "1.0.1"
@@ -9928,7 +9950,7 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -9945,7 +9967,7 @@ isobject@^3.0.0, isobject@^3.0.1:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0:
   version "3.0.0"
@@ -10496,7 +10518,7 @@ js-yaml@^4.1.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
 jsdom@^16.4.0:
   version "16.7.0"
@@ -10579,7 +10601,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
 json3@^3.3.3:
   version "3.3.3"
@@ -10790,7 +10812,7 @@ last-call-webpack-plugin@^3.0.0:
 lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
-  integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
+  integrity sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -10848,16 +10870,16 @@ listr-verbose-renderer@^0.5.0:
     figures "^2.0.0"
 
 listr2@^3.8.3:
-  version "3.13.3"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.13.3.tgz#d8f6095c9371b382c9b1c2bc33c5941d8e177f11"
-  integrity sha512-VqAgN+XVfyaEjSaFewGPcDs5/3hBbWVaX1VgWv2f52MF7US45JuARlArULctiB44IIcEk3JF7GtoFCLqEdeuPA==
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.14.0.tgz#23101cc62e1375fd5836b248276d1d2b51fdbe9e"
+  integrity sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==
   dependencies:
     cli-truncate "^2.1.0"
-    clone "^2.1.2"
     colorette "^2.0.16"
     log-update "^4.0.0"
     p-map "^4.0.0"
-    rxjs "^7.4.0"
+    rfdc "^1.3.0"
+    rxjs "^7.5.1"
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
@@ -11024,7 +11046,7 @@ lodash.merge@^4.6.1, lodash.merge@^4.6.2:
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
-  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.pickby@4.6.0:
   version "4.6.0"
@@ -11079,11 +11101,12 @@ log-symbols@^1.0.2:
     chalk "^1.0.0"
 
 log-symbols@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
-  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
   dependencies:
-    chalk "^4.0.0"
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -11353,12 +11376,24 @@ mime-db@1.45.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 "mime-db@>= 1.43.0 < 2":
   version "1.46.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
   integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.28"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
   integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
@@ -11425,7 +11460,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -11448,10 +11483,15 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q= sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+
+minimist@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -12114,7 +12154,7 @@ on-headers@~1.0.2:
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
@@ -12195,7 +12235,7 @@ os-browserify@^0.3.0:
 ospath@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
-  integrity sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
+  integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
 
 p-each-series@^2.1.0:
   version "2.2.0"
@@ -12451,7 +12491,7 @@ path-exists@^5.0.0:
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-is-inside@^1.0.2:
   version "1.0.2"
@@ -12511,12 +12551,12 @@ pbkdf2@^3.0.3:
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
 picocolors@^0.2.1:
   version "0.2.1"
@@ -13450,7 +13490,7 @@ proxy-addr@~2.0.5:
 proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
-  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
+  integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -13462,15 +13502,10 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
-psl@^1.1.33:
+psl@^1.1.28, psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity "sha1-0N8qE38AeUVl/K87LADNCfjVpac= sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -13542,9 +13577,9 @@ qs@^6.9.4:
     side-channel "^1.0.4"
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@^4.1.0, query-string@^4.2.2:
   version "4.3.4"
@@ -14242,7 +14277,7 @@ repeat-string@^1.6.1:
 request-progress@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
-  integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
+  integrity sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==
   dependencies:
     throttleit "^1.0.0"
 
@@ -14415,6 +14450,11 @@ rework@1.0.1:
     convert-source-map "^0.3.3"
     css "^2.0.0"
 
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -14528,12 +14568,12 @@ rxjs@^6.3.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+rxjs@^7.5.1:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
   dependencies:
-    tslib "~2.1.0"
+    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -14690,10 +14730,17 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.2.1:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.2:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -14882,10 +14929,15 @@ side-channel@^1.0.3, side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+signal-exit@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -15146,7 +15198,22 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sshpk@^1.14.1, sshpk@^1.7.0:
+sshpk@^1.14.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
+  integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
+sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
   integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
@@ -15302,16 +15369,7 @@ string-width@^4.0.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15436,7 +15494,7 @@ strip-ansi@5.2.0, strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@6.0.0, strip-ansi@^6.0.0:
+strip-ansi@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
@@ -15457,7 +15515,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^6.0.1:
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15760,7 +15818,7 @@ throat@^5.0.0:
 throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
-  integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
+  integrity sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==
 
 through2@^2.0.0:
   version "2.0.5"
@@ -15773,7 +15831,7 @@ through2@^2.0.0:
 through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 thunky@^1.0.2:
   version "1.1.0"
@@ -15976,7 +16034,7 @@ tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@~2.1.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
@@ -16018,14 +16076,14 @@ tty@1.0.1:
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
   dependencies:
     safe-buffer "^5.0.1"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -16065,6 +16123,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"
@@ -16427,7 +16490,7 @@ vendors@^1.0.0:
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
   dependencies:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
@@ -16960,7 +17023,7 @@ wrap-ansi@^7.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 write-file-atomic@^3.0.0:
   version "3.0.3"
@@ -17115,7 +17178,7 @@ yarn@^1.21.1:
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -2421,6 +2421,46 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jridgewell/gen-mapping@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity "sha1-wa7cYehT8rufXf5tRELTtWWyU7k= sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A=="
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity "sha1-IgOxGMFXchrd/mnUe3BGVGMGbXg= sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI= sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity "sha1-9FNRqu1FJ6KYUS7HL4EEDJmFgPs= sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw=="
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity "sha1-rdTJjTQUcqKJGQtCTvvbCWmRuyQ= sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
+  integrity "sha1-eTBBJ3r5BzsJUaf+Dw2MTJjDaYU= sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g=="
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
+
 "@material-ui/core@^4.11.0":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
@@ -2902,6 +2942,11 @@
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.0.tgz#8293560f8f80a00383d6c755ec3e0b918acb1683"
   integrity sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==
+
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity "sha1-zLkURTYBeaBOf+av94wA/8Hur4I= sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -3777,6 +3822,11 @@ abab@^2.0.3:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
+abab@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity "sha1-QbgPLIcdGWhiFrgjCSMc/Tyz0pE= sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -3823,6 +3873,11 @@ acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+acorn@^8.2.4, acorn@^8.5.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity "sha1-Cj+cvsxOw76m8KgLZq6N0tolC3M= sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+
 acorn@^8.7.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
@@ -3840,6 +3895,13 @@ adjust-sourcemap-loader@3.0.0:
   dependencies:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c= sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -3957,9 +4019,9 @@ ansi-regex@^3.0.0:
   integrity "sha1-Ej1keekq1FrYl9QFTjx8p9tJROE= sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
 
 ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity "sha1-Fk2qyHqy1vbbOimHXi0XZlgtq+0= sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
 
 ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
@@ -4497,9 +4559,9 @@ async-limiter@~1.0.0:
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE= sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="
   dependencies:
     lodash "^4.17.14"
 
@@ -6365,7 +6427,7 @@ cssom@~0.3.6:
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
-cssstyle@^2.2.0:
+cssstyle@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
@@ -6488,6 +6550,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -6516,13 +6585,6 @@ debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -6536,10 +6598,10 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@^10.2.0:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
-  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
+decimal.js@^10.2.1:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
+  integrity "sha1-A0FlHR2ZfYYGWizjpEH70NjouY4= sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -7307,13 +7369,13 @@ escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escodegen@^1.14.1:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
-  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+escodegen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  integrity "sha1-XjKxKDPoqo+jXhvwvvqJOASEx90= sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw=="
   dependencies:
     esprima "^4.0.1"
-    estraverse "^4.2.0"
+    estraverse "^5.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
   optionalDependencies:
@@ -7645,7 +7707,7 @@ esrecurse@^4.1.0, esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -9086,6 +9148,15 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.3.tgz#01d2709c79d41698bb01d4decc5e9da4e4a033d9"
   integrity sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==
 
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity "sha1-ioyO9/WTLM+VPClsqCkblap0qjo= sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg=="
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -9127,6 +9198,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY= sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -9684,10 +9763,10 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-potential-custom-element-name@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
-  integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U= sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
 
 is-promise@^2.1.0:
   version "2.2.2"
@@ -10420,35 +10499,36 @@ jsbn@~0.1.0:
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsdom@^16.4.0:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.4.0.tgz#36005bde2d136f73eee1a830c6d45e55408edddb"
-  integrity sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710"
+  integrity "sha1-kYrnGWVCSxl8gZ+Bg6dU4Yl3txA= sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw=="
   dependencies:
-    abab "^2.0.3"
-    acorn "^7.1.1"
+    abab "^2.0.5"
+    acorn "^8.2.4"
     acorn-globals "^6.0.0"
     cssom "^0.4.4"
-    cssstyle "^2.2.0"
+    cssstyle "^2.3.0"
     data-urls "^2.0.0"
-    decimal.js "^10.2.0"
+    decimal.js "^10.2.1"
     domexception "^2.0.1"
-    escodegen "^1.14.1"
+    escodegen "^2.0.0"
+    form-data "^3.0.0"
     html-encoding-sniffer "^2.0.1"
-    is-potential-custom-element-name "^1.0.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-potential-custom-element-name "^1.0.1"
     nwsapi "^2.2.0"
-    parse5 "5.1.1"
-    request "^2.88.2"
-    request-promise-native "^1.0.8"
-    saxes "^5.0.0"
+    parse5 "6.0.1"
+    saxes "^5.0.1"
     symbol-tree "^3.2.4"
-    tough-cookie "^3.0.1"
+    tough-cookie "^4.0.0"
     w3c-hr-time "^1.0.2"
     w3c-xmlserializer "^2.0.0"
     webidl-conversions "^6.1.0"
     whatwg-encoding "^1.0.5"
     whatwg-mimetype "^2.3.0"
-    whatwg-url "^8.0.0"
-    ws "^7.2.3"
+    whatwg-url "^8.5.0"
+    ws "^7.4.6"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -10841,9 +10921,9 @@ loader-utils@2.0.0, loader-utils@^2.0.0:
     json5 "^2.1.2"
 
 loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity "sha1-KalX86Y5c4g+toTxD/09FR/sAaM= sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg=="
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
@@ -10986,7 +11066,7 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-lodash@4.17.21, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.1.1, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@~4.17.10:
+lodash@4.17.21, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.1.1, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11338,17 +11418,24 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@~3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.8.tgz#5e6a59bd11e2ab0de1cfb843eb2d82e546c321c1"
+  integrity "sha1-XmpZvRHiqw3hz7hD6y2C5UbDIcE= sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q=="
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -11456,9 +11543,9 @@ moment@2.29.1:
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 "moment@>= 2.9.0", moment@>=1.6.0, moment@^2.22.1:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity "sha1-7dR0EcMiQTmZ96WUDVJt4YPAMfM= sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity "sha1-Pb4FKIn+fBsu2Wb8s6dzKJZO8Qg= sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
 
 moo-color@^1.0.2:
   version "1.0.2"
@@ -12297,12 +12384,7 @@ parse5-htmlparser2-tree-adapter@^6.0.0:
   dependencies:
     parse5 "^6.0.1"
 
-parse5@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
-  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
-
-parse5@^6.0.0, parse5@^6.0.1:
+parse5@6.0.1, parse5@^6.0.0, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -13385,6 +13467,11 @@ psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity "sha1-0N8qE38AeUVl/K87LADNCfjVpac= sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -14159,22 +14246,6 @@ request-progress@^3.0.0:
   dependencies:
     throttleit "^1.0.0"
 
-request-promise-core@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
-  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
-  dependencies:
-    lodash "^4.17.19"
-
-request-promise-native@^1.0.8:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
-  integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
-  dependencies:
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
 request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
@@ -14532,7 +14603,7 @@ sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-saxes@^5.0.0:
+saxes@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
@@ -14956,10 +15027,18 @@ source-map-resolve@^0.6.0:
     atob "^2.1.2"
     decode-uri-component "^0.2.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity "sha1-BP58f54e0tZiIzwoyys1ufY/bk8= sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -14986,7 +15065,7 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -15132,11 +15211,6 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
-
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -15655,13 +15729,14 @@ terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.4:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.0.tgz#138cdf21c5e3100b1b3ddfddf720962f88badcd2"
-  integrity sha512-vyqLMoqadC1uR0vywqOZzriDYzgEkNJFK4q9GeyOBHIbiECHiWLKcWfbQWAUaPfxkjDhapSlZB9f7fkMrvkVjA==
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.1.tgz#8561af6e0fd6d839669c73b92bdd5777d870ed6c"
+  integrity "sha1-hWGvbg/W2DlmnHO5K91Xd9hw7Ww= sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw=="
   dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
     commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.19"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -15786,7 +15861,17 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
+tough-cookie@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
+  integrity "sha1-5T6EuF8k4LZd1Sb0ZijbbIX2uHQ= sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ=="
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
+tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -15794,19 +15879,17 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tough-cookie@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
-  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
-  dependencies:
-    ip-regex "^2.1.0"
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479"
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
+  dependencies:
+    punycode "^2.1.1"
+
+tr46@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
+  integrity "sha1-+oeqgcpdWUHajL8fm3SdyWmk4kA= sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw=="
   dependencies:
     punycode "^2.1.1"
 
@@ -16132,6 +16215,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity "sha1-ZFF2BWb6hXU0dFqx3elS0bF2G+A= sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -16200,7 +16288,7 @@ url-loader@4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
-url-parse@^1.5.1:
+url-parse@^1.5.1, url-parse@^1.5.3:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
@@ -16600,6 +16688,15 @@ whatwg-url@^8.0.0:
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
 
+whatwg-url@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
+  integrity "sha1-ZWp45RD/jzk3vAvL6fXArDWUG3c= sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg=="
+  dependencies:
+    lodash "^4.7.0"
+    tr46 "^2.1.0"
+    webidl-conversions "^6.1.0"
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -16882,10 +16979,10 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.2.3:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
-  integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
+ws@^7.4.6:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity "sha1-VPp9sp9MfOxosd3TqJ3gmZQrtZE= sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
 
 xml-name-validator@^3.0.0:
   version "3.0.0"

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,8 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/urfave/cli/v2 v2.8.1 h1:CGuYNZF9IKZY/rfBe3lJpccSoIY1ytfvmgQT90cNOl4=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=

--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -1057,6 +1057,9 @@ spec:
                   runtimeId:
                     type: string
                     description: runtime identifier
+                  capabilityId:
+                    type: string
+                    description: capability identifier
                   image:
                     type: object
                     properties:

--- a/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
+++ b/user-tools-operator/helm-charts/usertools/templates/statefulset.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: user-tools-{{ .Values.usernameSlug }}
         runtimeId: {{ .Values.vscodeRuntime.runtimeId }}
+        capabilityId: {{ .Values.vscodeRuntime.capabilityId }}
     spec:
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/user-tools-operator/helm-charts/usertools/values.yaml
+++ b/user-tools-operator/helm-charts/usertools/values.yaml
@@ -77,6 +77,7 @@ vscode:
 
 vscodeRuntime:
   runtimeId: "61383716a8c1d7ce4764f411"
+  capabilityId: "capability_id_1"
   image:
     repository: konstellation/kdl-py
     tag: "3.9"


### PR DESCRIPTION
**WHY**
Current KDL-Server does not have a filtering mechanism to select which type of nodes the user wants to deploy the user tools.

**WHAT**
A new selector has been added to the UI so the user can select the node in which the tools will be deployed.
The capabilities are a representation of NodeSelectors, and those should be introduced on the database by the DevOps so that the user can select them from the UI.

Also, cypress tests have been updated to match the expected new behaviours. 