### PR TITLE
refactor(helm): remove jupyter enterprise gateway

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -2,5 +2,4 @@ chart-dirs:
   - helm/
 chart-repos:
   - minio=https://charts.min.io/
-  - enterprise-gateway=https://konstellation-io.github.io/enterprise_gateway/   
 validate-maintainers: false

--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -5,7 +5,6 @@
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.min.io/ | minio | 3.2.0 |
-| https://konstellation-io.github.io/enterprise_gateway/ | enterprise-gateway | 2.6.0 |
 
 ## Values
 
@@ -63,7 +62,6 @@
 | droneRunner.serviceAccountJob.name | string | `"drone-runner-job"` | The name of the Drone job service account |
 | droneRunner.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | droneRunner.trace | string | `"true"` | Sets DRONE_TRACE environment variable |
-| enterprise-gateway | object | Check [values.yaml](./values.yaml) | Jupyter Enterprise Gateway chart values. Check chart's [values.yaml](https://github.com/konstellation-io/enterprise_gateway/blob/main/etc/kubernetes/helm/enterprise-gateway/values.yaml) for a complete list of values |
 | gitea.admin.email | string | `"test@test.com"` | Admin user email |
 | gitea.admin.password | string | `"123456"` | Admin password |
 | gitea.admin.username | string | `"kdladmin"` | Admin username |
@@ -91,7 +89,7 @@
 | kdlServer.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | kdlServer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | kdlServer.image.repository | string | `"konstellation/kdl-server"` | The image repository |
-| kdlServer.image.tag | string | `"1.28.0"` | The image tag |
+| kdlServer.image.tag | string | `"1.29.0"` | The image tag |
 | kdlServer.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"1000000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"3600","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"}` | Ingress annotations |
 | kdlServer.ingress.className | string | `"nginx"` | The ingress class name |
 | kdlServer.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
@@ -147,7 +145,7 @@
 | projectOperator.kubeRbacProxy.image.tag | string | `"v0.8.0"` | Image tag |
 | projectOperator.manager.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | projectOperator.manager.image.repository | string | `"konstellation/project-operator"` | The image repository |
-| projectOperator.manager.image.tag | string | `"0.18.0"` | The image tag |
+| projectOperator.manager.image.tag | string | `"0.19.0"` | The image tag |
 | projectOperator.manager.resources | object | `{}` | Resource requests and limits for primary projectOperator container. Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | projectOperator.mlflow.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | projectOperator.mlflow.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
@@ -172,9 +170,6 @@
 | userToolsOperator.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n","nginx.ingress.kubernetes.io/proxy-body-size":"1000000m"}` | Ingress annotations |
 | userToolsOperator.ingress.className | string | `"nginx"` | The ingress class name |
 | userToolsOperator.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
-| userToolsOperator.jupyter.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
-| userToolsOperator.jupyter.image.repository | string | `"konstellation/jupyter-gpu"` | The image repository |
-| userToolsOperator.jupyter.image.tag | string | `"v0.15.0"` | The image tag |
 | userToolsOperator.kubeconfig.enabled | bool | `false` | Whether to enable kubeconfig for using with VSCode remote development. Ref: https://code.visualstudio.com/docs/remote/remote-overview |
 | userToolsOperator.kubeconfig.externalServerUrl | string | `""` | The Kube API Server URL for using with VSCode remote development |
 | userToolsOperator.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/helm/kdl-server/Chart.lock
+++ b/helm/kdl-server/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: minio
   repository: https://charts.min.io/
   version: 3.2.0
-- name: enterprise-gateway
-  repository: https://konstellation-io.github.io/enterprise_gateway/
-  version: 2.6.0
-digest: sha256:b24dd765d669dfd29f0855375802028c14f453151a16087c1abcef6a917f8f7b
-generated: "2022-09-20T16:58:08.611923987+02:00"
+digest: sha256:45484fc0179c8dd999a8dd794f59914a9e5b0c0ae2fc3b6088db7154c3a87bb0
+generated: "2022-12-09T14:25:03.048733915+01:00"

--- a/helm/kdl-server/Chart.yaml
+++ b/helm/kdl-server/Chart.yaml
@@ -9,6 +9,3 @@ dependencies:
   - name: minio
     version: "3.2.0"
     repository: "https://charts.min.io/"
-  - name: enterprise-gateway
-    version: "2.6.0"
-    repository: "https://konstellation-io.github.io/enterprise_gateway/"

--- a/helm/kdl-server/README.md
+++ b/helm/kdl-server/README.md
@@ -20,7 +20,6 @@ $ helm install [RELEASE_NAME] konstellation-io/kdl-server
 ## Dependencies
 
 * [MinIO](https://github.com/minio/minio/tree/master/helm/minio)
-* [Jupyter Jupyter Enterprise Gateway](https://github.com/konstellation-io/enterprise_gateway)
 
 ## Uninstall chart
 

--- a/helm/kdl-server/crds/user-tools-operator-crd.yaml
+++ b/helm/kdl-server/crds/user-tools-operator-crd.yaml
@@ -975,24 +975,6 @@ spec:
                   giteaOauth2Configmap:
                     description: the configmap containing the oauth2 config
                     type: string
-              jupyter:
-                type: object
-                properties:
-                  image:
-                    type: object
-                    properties:
-                      repository:
-                        description: image repository
-                        type: string
-                      tag:
-                        description: image tag
-                        type: string
-                      pullPolicy:
-                        description: image pull policy
-                        type: string
-                  enterpriseGatewayUrl:
-                    description: enterprise gateway url
-                    type: string
               vscode:
                 type: object
                 properties:
@@ -1024,6 +1006,7 @@ spec:
                         description: image pull policy
                         type: string
                   mongodbURI:
+                    description: MongoDB URI
                     type: string
                 required:
                 - mongodbURI

--- a/helm/kdl-server/templates/app/configmap.yaml
+++ b/helm/kdl-server/templates/app/configmap.yaml
@@ -17,7 +17,6 @@ data:
   # URL Setup
   PROJECT_FILEBROWSER_URL: "{{ include "http.protocol" . }}://kdlapp.{{ .Values.global.domain }}/filebrowser/PROJECT_ID/"
   MINIO_ENDPOINT: "{{ .Release.Name }}-minio:9000"
-  USER_TOOLS_JUPYTER_URL: "{{ include "http.protocol" . }}://USERNAME-jupyter.{{ .Values.global.domain }}/lab/workspaces/REPO_FOLDER/tree/repos/REPO_FOLDER"
   USER_TOOLS_VSCODE_URL: "{{ include "http.protocol" . }}://USERNAME-code.{{ .Values.global.domain }}/?folder=/home/coder/repos/REPO_FOLDER"
   DRONE_URL: "{{ printf "%s://drone.%s" (include "http.protocol" . ) .Values.global.domain }}"
   DRONE_INTERNAL_URL: "http://drone"
@@ -67,11 +66,6 @@ data:
   VSCODE_IMG_REPO: "{{ .Values.userToolsOperator.vscode.image.repository }}"
   VSCODE_IMG_TAG: "{{ .Values.userToolsOperator.vscode.image.tag }}"
   VSCODE_IMG_PULLPOLICY: "{{ .Values.userToolsOperator.vscode.image.pullPolicy }}"
-
-  JUPYTER_IMG_REPO: "{{ .Values.userToolsOperator.jupyter.image.repository }}"
-  JUPYTER_IMG_TAG: "{{ .Values.userToolsOperator.jupyter.image.tag }}"
-  JUPYTER_IMG_PULLPOLICY: "{{ .Values.userToolsOperator.jupyter.image.pullPolicy }}"
-  JUPYTER_ENTERPRISE_GATEWAY_URL: http://enterprise-gateway:{{ index .Values "enterprise-gateway" "port" }}
 
   REPO_CLONER_IMG_REPO: "{{ .Values.userToolsOperator.repoCloner.image.repository }}"
   REPO_CLONER_IMG_TAG: "{{ .Values.userToolsOperator.repoCloner.image.tag }}"

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -261,61 +261,6 @@ giteaOauth2Setup:
     # -- The image pull policy
     pullPolicy: IfNotPresent
 
-# -- Jupyter Enterprise Gateway chart values. Check chart's [values.yaml](https://github.com/konstellation-io/enterprise_gateway/blob/main/etc/kubernetes/helm/enterprise-gateway/values.yaml) for a complete list of values
-# @default -- Check [values.yaml](./values.yaml)
-enterprise-gateway:
-  image: elyra/enterprise-gateway:2.5.0
-  imagePullPolicy: IfNotPresent
-  # The primary port on which Enterprise Gateway is servicing requests.
-  port: 8888
-  replicas: 1
-  logLevel: DEBUG
-  mirrorWorkingDirs: true
-
-  # create and require a secret token, supplied by client in an "Authorization: token" header
-  affinity: {}
-
-  kernel:
-    # Kernel cluster role created by this chart.
-    clusterRole: kernel-controller
-    # Will start kernels in the same namespace as EG if True.
-    shareGatewayNamespace: true
-    # ignored if shareGatewayNamespace
-    # kernelNamespace: jupyter-notebooks
-    # Timeout for kernel launching in seconds.
-    launchTimeout: 60
-    # Timeout for an idle kernel before its culled in seconds. Default is 1 hour.
-    cullIdleTimeout: 3600
-    # List of kernel names that are available for use.
-    whitelist:
-      - kdl-py3.9
-      - kdl-py3.9-cuda10.2-cudnn7
-      - kdl-py3.9-cuda11.6-cudnn8
-    # Default kernel name should be something from the whitelist
-    defaultKernelName: kdl-py3.9
-    # kernel service account name
-    serviceAccount: kernel-sa
-
-  kernelspecs:
-    # Optional custom data image containing kernelspecs to use.
-    image: "konstellation/jupyter-kernelspecs:1.1.0"
-    # Kernelspecs image pull policy.
-    imagePullPolicy: IfNotPresent
-
-  # Kernel Image Puller (daemonset)
-  kip:
-    enabled: true
-    # Kernel Image Puller image name and tag to use.
-    image: elyra/kernel-image-puller:2.5.0
-    # Kernel Image Puller image pull policy.
-    imagePullPolicy: IfNotPresent
-    # Determines whether the Kernel Image Puller will pull kernel images it has
-    # previously pulled
-    pullPolicy: Always
-    # The interval (in seconds) at which the Kernel Image Puller fetches
-    # kernelspecs to pull kernel images.
-    interval: 300
-
 knowledgeGalaxy:
   # -- Whether to enable Knowledge Galaxy
   enabled: false
@@ -620,14 +565,6 @@ userToolsOperator:
 
   ## The following components are managed by the manager container when `usertool` custom resources are detected
   ##
-  jupyter:
-    image:
-      # -- The image repository
-      repository: konstellation/jupyter-gpu
-      # -- The image tag
-      tag: v0.15.0
-      # -- The image pull policy
-      pullPolicy: IfNotPresent
   repoCloner:
     image:
       # -- The image repository

--- a/scripts/helmfile/helmfile.lock
+++ b/scripts/helmfile/helmfile.lock
@@ -1,0 +1,10 @@
+version: 0.146.0
+dependencies:
+- name: community-operator
+  repository: https://mongodb.github.io/helm-charts
+  version: 0.7.6
+- name: raw
+  repository: https://bedag.github.io/helm-charts/
+  version: 1.1.0
+digest: sha256:9932c7a1402270716551ae6d79feb083338b5e6e18a035fa3f955a681582ea50
+generated: "2022-12-12T16:49:00.686059825+01:00"

--- a/scripts/kdlctl/cmd_deploy.sh
+++ b/scripts/kdlctl/cmd_deploy.sh
@@ -103,5 +103,6 @@ deploy_helm_chart() {
     echo_info "KDL Remote Development enabled"
   fi
   echo_info "📦 Applying helm chart..."
+  helmfile -f scripts/helmfile/helmfile.yaml deps
   helmfile -f scripts/helmfile/helmfile.yaml apply
 }


### PR DESCRIPTION
**WHY**

Jupyter Notebook is being removed from KDL Server

**WHAT**

Removed all Jupyter Notebook references and Jupyter Enterprise Gateway dependency from the chart.

**BREAKING CHANGE**

* *usertools.kdl.konstellation.io* CRD has been updated, so it must be manually applied before upgrading the chart
* *Jupyter Enterprise Gateway* dependency has been removed
