### PR TITLE
KNT1-160 - Fix user synchronization when the Gitea username changes.

### DIFF
--- a/app/api/infrastructure/repository/user.go
+++ b/app/api/infrastructure/repository/user.go
@@ -178,7 +178,7 @@ func (m *userMongoDBRepo) UpdateEmail(ctx context.Context, username, email strin
 }
 
 func (m *userMongoDBRepo) UpdateUsername(ctx context.Context, email, username string) error {
-	m.logger.Debugf("Updating user \"%s\" with \"%#v\"...", email)
+	m.logger.Debugf("Updating user %q with email %q ...", username, email)
 
 	filter := bson.M{"email": email}
 

--- a/app/api/infrastructure/repository/user.go
+++ b/app/api/infrastructure/repository/user.go
@@ -177,6 +177,20 @@ func (m *userMongoDBRepo) UpdateEmail(ctx context.Context, username, email strin
 	return m.updateUserFields(ctx, username, bson.M{"email": email})
 }
 
+func (m *userMongoDBRepo) UpdateUsername(ctx context.Context, email, username string) error {
+	m.logger.Debugf("Updating user \"%s\" with \"%#v\"...", email)
+
+	filter := bson.M{"email": email}
+
+	fields := bson.M{"username": username, "deleted": false}
+
+	_, err := m.collection.UpdateOne(ctx, filter, bson.M{
+		"$set": fields,
+	})
+
+	return err
+}
+
 func (m *userMongoDBRepo) UpdateDeleted(ctx context.Context, username string, deleted bool) error {
 	return m.updateUserFields(ctx, username, bson.M{"deleted": deleted})
 }

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -61,8 +61,8 @@ func newUserSuite(t *testing.T, cfg *config.Config) *userSuite {
 		cfg = &config.Config{}
 	}
 
-	interactor := user.NewInteractor(logger, *cfg, repo, repoRuntimes, repoCapabilities, sshGenerator, clockMock,
-		giteaServiceMock, k8sClientMock)
+	interactor := user.NewInteractor(logger, *cfg, repo, repoRuntimes, repoCapabilities, sshGenerator,
+		clockMock, giteaServiceMock, k8sClientMock)
 
 	return &userSuite{
 		ctrl:       ctrl,

--- a/app/api/usecase/user/interactor_users_sync.go
+++ b/app/api/usecase/user/interactor_users_sync.go
@@ -41,6 +41,7 @@ func (i *interactor) syncUsers() {
 	}
 
 	usersMap := i.userListToMap(users)
+	emailsMap := i.userEmailListToMap(users)
 
 	giteaUsers, err := i.giteaService.FindAllUsers()
 	if err != nil {
@@ -48,39 +49,52 @@ func (i *interactor) syncUsers() {
 		return
 	}
 
-	giteaUsersMap := i.userListToMap(giteaUsers)
-
 	//nolint:prealloc // the final slice length is unknown
 	var (
-		usersToUpd     []entity.User
-		usersToAdd     []entity.User
-		usersToDel     []entity.User
-		usersToRestore []entity.User
+		usersEmailsToUpd []entity.User
+		usernamesToUpd   []entity.User
+		usersToAdd       []entity.User
+		usersToDel       []entity.User
+		usersToRestore   []entity.User
 	)
 
 	// Get the users to update or to add
 	for _, giteaUser := range giteaUsers {
-		u, found := usersMap[giteaUser.Username]
+		u, userFound := usersMap[giteaUser.Username]
+		_, emailFound := emailsMap[giteaUser.Email]
 
-		if !found {
-			i.logger.Debugf("The gitea user \"%s\" is a new user", giteaUser.Username)
+		toBeCreated := !userFound && !emailFound
+
+		// When a username is modified in Gitea, the user is internally deleted an
+		// recreated with the new username, that's why the !emailFound check is done
+		toBeDeleted := !toBeCreated && u.Deleted && !emailFound
+
+		toBeUpdated := !toBeDeleted && (!userFound || !emailFound)
+
+		switch {
+		case toBeCreated:
+			i.logger.Debugf("The gitea user %q with email %q is a new user", giteaUser.Username, giteaUser.Email)
+
 			usersToAdd = append(usersToAdd, giteaUser)
 
-			continue
-		}
-
-		if u.Deleted {
+		case toBeDeleted:
 			i.logger.Debugf("The gitea user \"%s\" has been restored", u.Username)
 
 			usersToRestore = append(usersToRestore, giteaUser)
-		}
 
-		if u.Email != giteaUser.Email {
+		case toBeUpdated:
 			i.logger.Debugf("The gitea user \"%s\" has changed their email", u.Username)
 
-			usersToUpd = append(usersToUpd, giteaUser)
+			if userFound {
+				usersEmailsToUpd = append(usersEmailsToUpd, giteaUser)
+			} else {
+				usernamesToUpd = append(usernamesToUpd, giteaUser)
+			}
 		}
 	}
+
+	giteaUsersMap := i.userListToMap(giteaUsers)
+	giteaEmailsMap := i.userEmailListToMap(giteaUsers)
 
 	// Get the users to delete
 	for _, u := range users {
@@ -88,11 +102,14 @@ func (i *interactor) syncUsers() {
 			continue
 		}
 
-		if _, found := giteaUsersMap[u.Username]; found {
+		_, usernameExists := giteaUsersMap[u.Username]
+		_, emailExists := giteaEmailsMap[u.Email]
+
+		if usernameExists || emailExists {
 			continue
 		}
 
-		i.logger.Debugf("The gitea user \"%s\" has been deleted", u.Username)
+		i.logger.Debugf("The gitea user %q has been deleted", u.Username)
 		usersToDel = append(usersToDel, u)
 	}
 
@@ -100,7 +117,8 @@ func (i *interactor) syncUsers() {
 
 	i.syncDelUsers(ctx, usersToDel, &wg)
 	i.syncRestoreUsers(ctx, usersToRestore, &wg)
-	i.syncUpdateUsers(ctx, usersToUpd, &wg)
+	i.syncUpdateUserEmails(ctx, usersEmailsToUpd, &wg)
+	i.syncUpdateUsernames(ctx, usernamesToUpd, &wg)
 	i.syncAddUsers(ctx, usersToAdd, &wg)
 
 	wg.Wait()
@@ -123,7 +141,7 @@ func (i *interactor) syncAddUsers(ctx context.Context, users []entity.User, wg *
 	}
 }
 
-func (i *interactor) syncUpdateUsers(ctx context.Context, users []entity.User, wg *sync.WaitGroup) {
+func (i *interactor) syncUpdateUserEmails(ctx context.Context, users []entity.User, wg *sync.WaitGroup) {
 	for _, u := range users {
 		wg.Add(1)
 
@@ -131,6 +149,21 @@ func (i *interactor) syncUpdateUsers(ctx context.Context, users []entity.User, w
 			defer wg.Done()
 
 			err := i.repo.UpdateEmail(ctx, userToUpd.Username, userToUpd.Email)
+			if err != nil {
+				i.logger.Errorf("Error updating user \"%s\": %s", userToUpd.Username, err)
+			}
+		}(u)
+	}
+}
+
+func (i *interactor) syncUpdateUsernames(ctx context.Context, users []entity.User, wg *sync.WaitGroup) {
+	for _, u := range users {
+		wg.Add(1)
+
+		go func(userToUpd entity.User) {
+			defer wg.Done()
+
+			err := i.repo.UpdateUsername(ctx, userToUpd.Email, userToUpd.Username)
 			if err != nil {
 				i.logger.Errorf("Error updating user \"%s\": %s", userToUpd.Username, err)
 			}
@@ -187,6 +220,16 @@ func (i *interactor) userListToMap(users []entity.User) map[string]entity.User {
 
 	for _, u := range users {
 		usersMap[u.Username] = u
+	}
+
+	return usersMap
+}
+
+func (i *interactor) userEmailListToMap(users []entity.User) map[string]entity.User {
+	usersMap := map[string]entity.User{}
+
+	for _, u := range users {
+		usersMap[u.Email] = u
 	}
 
 	return usersMap

--- a/app/api/usecase/user/interactor_users_sync.go
+++ b/app/api/usecase/user/interactor_users_sync.go
@@ -123,6 +123,7 @@ func (i *interactor) syncGiteaUsersToUpdate(users, giteaUsers []entity.User) (us
 			usernamesToUpd = append(usernamesToUpd, giteaUser)
 		}
 	}
+
 	return usersToAdd, usersToRestore, usersEmailsToUpd, usernamesToUpd
 }
 

--- a/app/api/usecase/user/interactor_users_sync_internal_test.go
+++ b/app/api/usecase/user/interactor_users_sync_internal_test.go
@@ -1,0 +1,135 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/konstellation-io/kdl-server/app/api/entity"
+	"github.com/konstellation-io/kdl-server/app/api/pkg/logging"
+	"github.com/stretchr/testify/suite"
+)
+
+type UsersSyncTestSuite struct {
+	suite.Suite
+	interactor *interactor
+}
+
+func TestUsersSyncTestSuite(t *testing.T) {
+	suite.Run(t, new(UsersSyncTestSuite))
+}
+
+func (testSuite *UsersSyncTestSuite) SetupSuite() {
+	logger := logging.NewLogger("debug")
+
+	testSuite.interactor = &interactor{
+		logger: logger,
+	}
+}
+
+func (testSuite *UsersSyncTestSuite) getUser(deleted bool) entity.User {
+	return entity.User{
+		ID:       "1",
+		Email:    "test-1@test.com",
+		Username: "test1",
+		Deleted:  deleted,
+	}
+}
+
+func (testSuite *UsersSyncTestSuite) TestInteractor_SyncGiteaUsersToUpdate_CreateNewUser_ExpectOk() {
+	giteaUsers := []entity.User{
+		testSuite.getUser(false),
+	}
+	kaiLabUsers := []entity.User{}
+
+	usersToAdd, usersToRestore, usersEmailsToUpd, usernamesToUpd := testSuite.interactor.syncGiteaUsersToUpdate(kaiLabUsers, giteaUsers)
+
+	testSuite.Assert().Len(usersToAdd, 1)
+	testSuite.Assert().Contains(usersToAdd, testSuite.getUser(false))
+	testSuite.Assert().Empty(usersToRestore)
+	testSuite.Assert().Empty(usersEmailsToUpd)
+	testSuite.Assert().Empty(usernamesToUpd)
+}
+
+func (testSuite *UsersSyncTestSuite) TestInteractor_SyncGiteaUsersToUpdate_RestoreUser_ExpectOk() {
+	giteaUsers := []entity.User{
+		testSuite.getUser(false),
+	}
+
+	kaiLabUsers := []entity.User{
+		testSuite.getUser(true),
+	}
+
+	usersToAdd, usersToRestore, usersEmailsToUpd, usernamesToUpd := testSuite.interactor.syncGiteaUsersToUpdate(kaiLabUsers, giteaUsers)
+
+	testSuite.Assert().Empty(usersToAdd)
+	testSuite.Assert().Len(usersToRestore, 1)
+	testSuite.Assert().Contains(usersToRestore, testSuite.getUser(false))
+	testSuite.Assert().Empty(usersEmailsToUpd)
+	testSuite.Assert().Empty(usernamesToUpd)
+}
+
+func (testSuite *UsersSyncTestSuite) TestInteractor_SyncGiteaUsersToUpdate_UpdateUserEmail_ExpectOk() {
+	userToUpdate := entity.User{
+		ID:       "1",
+		Email:    "test-2@test.com",
+		Username: "test1",
+		Deleted:  false,
+	}
+
+	giteaUsers := []entity.User{
+		userToUpdate,
+	}
+	kaiLabUsers := []entity.User{
+		testSuite.getUser(false),
+	}
+
+	usersToAdd, usersToRestore, usersEmailsToUpd, usernamesToUpd := testSuite.interactor.syncGiteaUsersToUpdate(kaiLabUsers, giteaUsers)
+
+	testSuite.Assert().Empty(usersToAdd)
+	testSuite.Assert().Empty(usersToRestore)
+	testSuite.Assert().Len(usersEmailsToUpd, 1)
+	testSuite.Assert().Contains(usersEmailsToUpd, userToUpdate)
+	testSuite.Assert().Empty(usernamesToUpd)
+}
+
+func (testSuite *UsersSyncTestSuite) TestInteractor_SyncGiteaUsersToUpdate_UpdateExistingUsername_ExpectOk() {
+	userToUpdate := entity.User{
+		ID:       "2",
+		Email:    "test-1@test.com",
+		Username: "test2",
+		Deleted:  false,
+	}
+
+	giteaUsers := []entity.User{
+		userToUpdate,
+	}
+	kaiLabUsers := []entity.User{
+		testSuite.getUser(false),
+	}
+
+	usersToAdd, usersToRestore, usersEmailsToUpd, usernamesToUpd := testSuite.interactor.syncGiteaUsersToUpdate(kaiLabUsers, giteaUsers)
+
+	testSuite.Assert().Empty(usersToAdd)
+	testSuite.Assert().Empty(usersToRestore)
+	testSuite.Assert().Empty(usersEmailsToUpd)
+	testSuite.Require().Len(usernamesToUpd, 1)
+	testSuite.Assert().Contains(usernamesToUpd, userToUpdate)
+}
+
+func (testSuite *UsersSyncTestSuite) TestInteractor_SyncGiteaUsersToUpdate_Delete_ExpectOk() {
+	giteaUsers := []entity.User{
+		{
+			ID:       "2",
+			Email:    "test-2@test.com",
+			Username: "test2",
+			Deleted:  false,
+		},
+	}
+	kaiLabUsers := []entity.User{
+		testSuite.getUser(false),
+	}
+
+	usersToDelete := testSuite.interactor.syncGiteaUsersToDelete(giteaUsers, kaiLabUsers)
+
+	testSuite.Require().Len(usersToDelete, 1)
+	testSuite.Assert().Contains(usersToDelete, testSuite.getUser(false))
+}

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -21,6 +21,7 @@ type Repository interface {
 	FindAll(ctx context.Context, includeDeleted bool) ([]entity.User, error)
 	FindByIDs(ctx context.Context, userIDs []string) ([]entity.User, error)
 	UpdateEmail(ctx context.Context, userID, email string) error
+	UpdateUsername(ctx context.Context, email, userID string) error
 	UpdateDeleted(ctx context.Context, userID string, deleted bool) error
 }
 

--- a/app/api/usecase/user/mocks_interface.go
+++ b/app/api/usecase/user/mocks_interface.go
@@ -182,6 +182,19 @@ func (mr *MockRepositoryMockRecorder) UpdateEmail(ctx, userID, email interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEmail", reflect.TypeOf((*MockRepository)(nil).UpdateEmail), ctx, userID, email)
 }
 
+
+func (m *MockRepository) UpdateUsername(ctx context.Context, userID, email string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUsername", ctx, email, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (mr *MockRepositoryMockRecorder) UpdateUsername(ctx, email, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUsername", reflect.TypeOf((*MockRepository)(nil).UpdateUsername), ctx, email, userID)
+}
+
 // UpdateSSHKey mocks base method.
 func (m *MockRepository) UpdateSSHKey(ctx context.Context, username string, SSHKey entity.SSHKey) error {
 	m.ctrl.T.Helper()

--- a/app/api/usecase/user/mocks_interface.go
+++ b/app/api/usecase/user/mocks_interface.go
@@ -182,7 +182,6 @@ func (mr *MockRepositoryMockRecorder) UpdateEmail(ctx, userID, email interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEmail", reflect.TypeOf((*MockRepository)(nil).UpdateEmail), ctx, userID, email)
 }
 
-
 func (m *MockRepository) UpdateUsername(ctx context.Context, userID, email string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUsername", ctx, email, userID)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to improve the Gitea users synchronization method to allow Gitea specific behaviours when changing the username.

## Motivation and Context
When a username is modified in Gitea, the default behavior is to remove the current user and create a new user with the updated username.
As we are listening for user modification events, when receiving the user deletion event from Gitea we are logically deleting the user in our database.
When receiving the new user-created event with the new username, the user cannot be created in our db, as we don't allow to add multiple users with the same email, and there is already an existing deleted user with that email.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
