### PR TITLE
feat: Pass additional options to backup CronJob (closes KNT1-206)

### DIFF
--- a/helm/kdl-server/CHART.md
+++ b/helm/kdl-server/CHART.md
@@ -11,10 +11,12 @@
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backup.activeDeadlineSeconds | int | `3600` | Sets the activeDeadlineSeconds param for the backup cronjob. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup |
-| backup.backoffLimit | int | `3` | Sets tge backoffLimit param for the backup cronjob. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy |
+| backup.backoffLimit | int | `3` | Sets the backoffLimit param for the backup cronjob. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy |
+| backup.concurrencyPolicy | string | `"Forbid"` | Specifies how to treat concurrent executions of a Job. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy |
 | backup.enabled | bool | `false` | Whether to enable backup |
 | backup.extraVolumeMounts | list | `[]` | Extra volume mounts for backup pods |
 | backup.extraVolumes | list | `[]` | Extra volumes for backup pods |
+| backup.failedJobsHistoryLimit | int | `1` | The number of failed finished jobs to retain. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | backup.image.repository | string | `"konstellation/kdl-backup"` | Image repository |
 | backup.image.tag | string | `"0.23.0"` | Image tag |
@@ -24,6 +26,9 @@
 | backup.s3.awsSecretAccessKey | string | `"aws-secret-access-key"` | AWS Secret Access Key for acceding backup bucket |
 | backup.s3.bucketName | string | `"s3-bucket-name"` | The S3 bucket that will store all backups |
 | backup.schedule | string | `"0 1 * * 0"` | Backup cronjob schedule |
+| backup.startingDeadlineSeconds | int | `60` | Optional deadline in seconds for starting the job if it misses scheduled time for any reason. Missed jobs executions will be counted as failed ones. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#job-creation |
+| backup.successfulJobsHistoryLimit | int | `0` | The number of successful finished jobs to retain. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits |
+| backup.ttlSecondsAfterFinished | string | `""` | Limits the lifetime of a Job that has finished execution (either Complete or Failed). |
 | cleaner.enabled | bool | `false` | Whether to enable cleaner cronjob |
 | cleaner.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | cleaner.image.repository | string | `"konstellation/cleaner"` | The image repository |
@@ -47,7 +52,7 @@
 | drone.tolerations | list | `[]` | If specified, the pod's tolerations. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | droneAuthorizer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | droneAuthorizer.image.repository | string | `"konstellation/drone-authorizer"` | The image repository |
-| droneAuthorizer.image.tag | string | `"v0.13.5"` | The image tag |
+| droneAuthorizer.image.tag | string | `"0.16.0"` | The image tag |
 | droneRunner.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | droneRunner.debug | string | `"true"` | Sets DRONE_DEBUG environment variable |
 | droneRunner.droneRunnerEnviron | string | `""` | Configures the DRONE_RUNNER_ENVIRON environment variable. Ref: https://docs.drone.io/runner/kubernetes/configuration/reference/drone-runner-environ/ |
@@ -89,7 +94,7 @@
 | kdlServer.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | kdlServer.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | kdlServer.image.repository | string | `"konstellation/kdl-server"` | The image repository |
-| kdlServer.image.tag | string | `"1.29.0"` | The image tag |
+| kdlServer.image.tag | string | `"1.35.0"` | The image tag |
 | kdlServer.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"1000000m","nginx.ingress.kubernetes.io/proxy-connect-timeout":"3600","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"}` | Ingress annotations |
 | kdlServer.ingress.className | string | `"nginx"` | The ingress class name |
 | kdlServer.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |
@@ -166,7 +171,7 @@
 | userToolsOperator.affinity | object | `{}` | Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | userToolsOperator.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | userToolsOperator.image.repository | string | `"konstellation/user-tools-operator"` | The image repository |
-| userToolsOperator.image.tag | string | `"0.26.0"` | The image tag |
+| userToolsOperator.image.tag | string | `"0.29.0"` | The image tag |
 | userToolsOperator.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"more_set_headers \"Content-Security-Policy: frame-ancestors 'self' *\";\n","nginx.ingress.kubernetes.io/proxy-body-size":"1000000m"}` | Ingress annotations |
 | userToolsOperator.ingress.className | string | `"nginx"` | The ingress class name |
 | userToolsOperator.ingress.tls.secretName | string | `nil` | The TLS secret name that will be used. It takes precedence over `.Values.global.ingress.tls.secretName`. |

--- a/helm/kdl-server/templates/backup/cronjob.yaml
+++ b/helm/kdl-server/templates/backup/cronjob.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.backup.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: backup
@@ -7,16 +7,17 @@ metadata:
     app: backup
 spec:
   schedule: {{ .Values.backup.schedule | quote }}
-  concurrencyPolicy: Forbid
-  failedJobsHistoryLimit: 5
-  successfulJobsHistoryLimit: 2
-  startingDeadlineSeconds: 60 # 1min
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  startingDeadlineSeconds: {{ .Values.backup.startingDeadlineSeconds }}
   jobTemplate:
     metadata:
       name: {{ .Values.backup.name }}
     spec:
       backoffLimit: {{ .Values.backup.backoffLimit }}
       activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished }}
       template:
         spec:
           securityContext:

--- a/helm/kdl-server/values.yaml
+++ b/helm/kdl-server/values.yaml
@@ -38,11 +38,26 @@ backup:
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
+  # -- Specifies how to treat concurrent executions of a Job. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy
+  concurrencyPolicy: Forbid
+
+  # -- The number of failed finished jobs to retain. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits
+  failedJobsHistoryLimit: 1
+
+  # -- The number of successful finished jobs to retain. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits
+  successfulJobsHistoryLimit: 0
+
+  # -- Optional deadline in seconds for starting the job if it misses scheduled time for any reason. Missed jobs executions will be counted as failed ones. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#job-creation
+  startingDeadlineSeconds: 60
+
+  # -- Sets the backoffLimit param for the backup cronjob. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+  backoffLimit: 3
+
   # -- Sets the activeDeadlineSeconds param for the backup cronjob. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup
   activeDeadlineSeconds: 3600
 
-  # -- Sets tge backoffLimit param for the backup cronjob. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
-  backoffLimit: 3
+  # -- Limits the lifetime of a Job that has finished execution (either Complete or Failed).
+  ttlSecondsAfterFinished: ""
 
   s3:
     # -- AWS Access Key ID for acceding backup bucket
@@ -142,7 +157,7 @@ drone:
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -194,7 +209,7 @@ droneRunner:
     annotations: {}
     #  eks.amazonaws.com/role-arn: "arn:aws:iam::1234567890:role/myrole"
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -243,7 +258,7 @@ gitea:
       # nginx.ingress.kubernetes.io/configuration-snippet: |
       #   more_set_headers "Content-Security-Policy: frame-ancestors 'self' https://kdlapp.kdl.local";
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -297,7 +312,7 @@ knowledgeGalaxy:
     imagePullSecrets: []
     # - name: regcred
 
-    # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -344,7 +359,7 @@ kdlServer:
       # nginx.ingress.kubernetes.io/proxy-body-size: "1000000m"
       # cert-manager.io/issuer: your-issuer
 
-      # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # -- Define which Nodes the Pods are scheduled on. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
 
   # -- Assign custom affinity rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added following values to be passed to backup CronJob:
```yaml
backup:
  concurrencyPolicy: Forbid
  failedJobsHistoryLimit: 1
  successfulJobsHistoryLimit: 0
  startingDeadlineSeconds: 60
  backoffLimit: 3
  activeDeadlineSeconds: 3600
  ttlSecondsAfterFinished: ""
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Most of the values of the relevant Backup CronJob spec were hard-coded in its template. This caused finished jobs to remain in the cluster as "Completed" or "Failed" pods for a fixed amount of time. If it was necessary for the completed pods to be deleted before that time, the user had to do it manually.

This PR changes the CronJob template making possible to set those values from the chart's _values.yaml_ file

<!--- If it fixes an open issue, please link to the issue here. -->
 Closes https://intelygenz.atlassian.net/browse/KNT1-206

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [X] I have updated the documentation accordingly.
