### PR TITLE
fix(api): [KDL6-34] tolerationSeconds downcasting

### DIFF
--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -156,7 +156,7 @@ func checkTolerationSeconds(toleration map[string]interface{}) error {
 	seconds, ok := toleration["tolerationSeconds"] // optional
 
 	if ok {
-		_, isNumber := seconds.(int64)
+		_, isNumber := seconds.(int32)
 		if !isNumber {
 			return wrapErrWithValue(ErrCapabilitiesInvalidSeconds, fmt.Sprintf("%v", seconds))
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change tolerationSeconds downcasting from int64 to int32

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
tolerationSeconds implements int32 interface{} not int64

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
