### PR TITLE
fix: restore create admin on kdl app startup

### DIFF
--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -93,8 +93,14 @@ func main() {
 
 	userInteractor := user.NewInteractor(logger, cfg, userRepo, runtimeRepo, capabilitiesRepo,
 		sshHelper, realClock, giteaService, k8sClient)
+
 	if err = userInteractor.SynchronizeServiceAccountsForUsers(); err != nil {
 		logger.Error(err, "Unexpected error creating serviceAccount for users")
+	}
+
+	err = userInteractor.CreateAdminUser(cfg.Admin.Username, cfg.Admin.Email)
+	if err != nil {
+		logger.Error(err, "Unexpected error creating admin user")
 	}
 
 	projectDeps := &project.InteractorDeps{

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -350,6 +350,32 @@ func (i *interactor) SynchronizeServiceAccountsForUsers() error {
 	return nil
 }
 
+// CreateAdminUser creates the KDL admin user if not exists.
+func (i *interactor) CreateAdminUser(username, email string) error {
+	ctx := context.Background()
+
+	_, err := i.repo.GetByUsername(ctx, username)
+	if err == nil {
+		i.logger.Info("The admin user already exists", "username", username)
+		return nil
+	}
+
+	if !errors.Is(err, entity.ErrUserNotFound) {
+		return err
+	}
+
+	i.logger.Info("Creating the admin user", "username", username)
+
+	user, err := i.Create(ctx, email, username, entity.AccessLevelAdmin)
+	if err != nil {
+		return err
+	}
+
+	i.logger.Info("Admin user created correctly", "username", user.Username, "userEmail", user.Email, "insertedID", user.ID)
+
+	return nil
+}
+
 // GetKubeconfig returns user kubeconfig.
 func (i *interactor) GetKubeconfig(ctx context.Context, username string) (string, error) {
 	running, err := i.k8sClient.IsUserToolPODRunning(ctx, username)

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -27,6 +27,7 @@ type Repository interface {
 // UseCase interface to manage all operations related with users.
 type UseCase interface {
 	Create(ctx context.Context, email, username string, accessLevel entity.AccessLevel) (entity.User, error)
+	CreateAdminUser(username, email string) error
 	UpdateAccessLevel(ctx context.Context, userIds []string, level entity.AccessLevel) ([]entity.User, error)
 	FindAll(ctx context.Context) ([]entity.User, error)
 	GetByUsername(ctx context.Context, username string) (entity.User, error)

--- a/hack/kdlctl.sh
+++ b/hack/kdlctl.sh
@@ -108,6 +108,12 @@ case $COMMAND in
     exit 0
   ;;
 
+  kdl)
+    build_server "$@"
+    echo_done "Dev environment created"
+    exit 0
+  ;;
+
   login)
     cmd_login "$@"
     echo_done "Login done"


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Restore create  kdladmin on startup until creation of user development is completed.

## PR Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Please check if your PR fulfills the following requirements:

- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [ ] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
