### PR TITLE
feat: [KDL6-3] default oauth2 credentials

### DIFF
--- a/hack/scripts/helmfile/values/initial-resources/values.yaml
+++ b/hack/scripts/helmfile/values/initial-resources/values.yaml
@@ -407,7 +407,7 @@ resources:
               "enabled": true,
               "alwaysDisplayInConsole": true,
               "clientAuthenticatorType": "client-secret",
-              "secret": "**********",
+              "secret": "proxy654321",
               "redirectUris": [
                 "https://kdlapp.kdl.10.0.1.1.nip.io/oauth2/callback"
               ],

--- a/hack/scripts/helmfile/values/kdl-local/values.yaml.gotmpl
+++ b/hack/scripts/helmfile/values/kdl-local/values.yaml.gotmpl
@@ -288,7 +288,7 @@ oauth2proxy:
     - "--skip-auth-route=/config.json"
   config:
     clientID: proxy
-    clientSecret: Zj6LksErcd51Q5LQS1YH4WLsTu3YVI4M
+    clientSecret: proxy654321
     configFile: |-
       provider="keycloak-oidc"
       oidc_issuer_url="https://keycloak.{{ requiredEnv "DOMAIN" }}/realms/kdl"


### PR DESCRIPTION
## Motivation and Context

This eliminates the manual steps of creating realm client credentials by passing a default client secret along with the initial configuration.

