### PR TITLE
feat: [KLD6-182] store sub in user entity

### DIFF
--- a/app/api/entity/user.go
+++ b/app/api/entity/user.go
@@ -28,6 +28,7 @@ type User struct {
 	ID           string
 	Email        string
 	Username     string
+	Sub          string
 	Deleted      bool
 	CreationDate time.Time
 	AccessLevel  AccessLevel

--- a/app/api/http/middleware/auth_test.go
+++ b/app/api/http/middleware/auth_test.go
@@ -110,6 +110,7 @@ func (ts *AuthMiddlewareTestSuite) TestMiddlewareAuthUsernameNotFound() {
 		id            = "user.1234"
 		email         = "user@email.com"
 		username      = "user"
+		sub           = "d5d70477-5192-4182-b80e-5d34550eb4fe"
 		accessLevel   = entity.AccessLevelViewer
 		publicSSHKey  = "test-ssh-key-public"
 		privateSSHKey = "test-ssh-key-private"
@@ -127,6 +128,7 @@ func (ts *AuthMiddlewareTestSuite) TestMiddlewareAuthUsernameNotFound() {
 	u := entity.User{
 		Username:     username,
 		Email:        email,
+		Sub:          sub,
 		AccessLevel:  accessLevel,
 		SSHKey:       sshKey,
 		CreationDate: now,
@@ -135,6 +137,7 @@ func (ts *AuthMiddlewareTestSuite) TestMiddlewareAuthUsernameNotFound() {
 		ID:           id,
 		Username:     username,
 		Email:        email,
+		Sub:          sub,
 		AccessLevel:  accessLevel,
 		SSHKey:       sshKey,
 		CreationDate: now,
@@ -143,6 +146,7 @@ func (ts *AuthMiddlewareTestSuite) TestMiddlewareAuthUsernameNotFound() {
 	ts.mocks.repo.EXPECT().GetByEmail(ctx, email).Return(entity.User{}, entity.ErrUserNotFound)
 	ts.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(entity.User{}, entity.ErrUserNotFound)
 	ts.mocks.repo.EXPECT().GetByEmail(ctx, email).Return(entity.User{}, entity.ErrUserNotFound)
+	ts.mocks.repo.EXPECT().GetBySub(ctx, sub).Return(entity.User{}, entity.ErrUserNotFound)
 	ts.mocks.clock.EXPECT().Now().Return(now)
 	ts.mocks.sshGenerator.EXPECT().NewKeys().Return(sshKey, nil)
 	ts.mocks.repo.EXPECT().Create(ctx, u).Return(id, nil)
@@ -157,7 +161,7 @@ func (ts *AuthMiddlewareTestSuite) TestMiddlewareAuthUsernameNotFound() {
 
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req.Header.Set("X-Forwarded-Email", email)
-	req.Header.Set("X-Forwarded-User", username)
+	req.Header.Set("X-Forwarded-User", sub)
 
 	res := httptest.NewRecorder()
 

--- a/app/api/infrastructure/mongodb/user.go
+++ b/app/api/infrastructure/mongodb/user.go
@@ -26,6 +26,7 @@ type userDTO struct {
 	Deleted            bool               `bson:"deleted"`
 	Username           string             `bson:"username"`
 	Email              string             `bson:"email"`
+	Sub                string             `bson:"sub"`
 	CreationDate       time.Time          `bson:"creation_date"`
 	AccessLevel        string             `bson:"access_level"`
 	PublicSSHKey       string             `bson:"public_ssh_key"`
@@ -67,6 +68,12 @@ func (m *UserRepo) EnsureIndexes() error {
 				Unique: &unique,
 			},
 		},
+		{
+			Keys: bson.M{"sub": 1},
+			Options: &options.IndexOptions{
+				Unique: &unique,
+			},
+		},
 	})
 
 	m.logger.Info("Indexes created for collection", "result", result, "collection", userCollName)
@@ -92,6 +99,11 @@ func (m *UserRepo) GetByUsername(ctx context.Context, username string) (entity.U
 // GetByEmail retrieves the user using their user email.
 func (m *UserRepo) GetByEmail(ctx context.Context, email string) (entity.User, error) {
 	return m.findOne(ctx, bson.M{"email": email})
+}
+
+// GetBySub retrieves the user using their user sub.
+func (m *UserRepo) GetBySub(ctx context.Context, sub string) (entity.User, error) {
+	return m.findOne(ctx, bson.M{"sub": sub})
 }
 
 // FindAll retrieves all the existing users.
@@ -260,6 +272,7 @@ func (m *UserRepo) entityToDTO(u entity.User) (userDTO, error) {
 	dto := userDTO{
 		Username:           u.Username,
 		Email:              u.Email,
+		Sub:                u.Sub,
 		AccessLevel:        string(u.AccessLevel),
 		PrivateSSHKey:      u.SSHKey.Private,
 		PublicSSHKey:       u.SSHKey.Public,
@@ -285,6 +298,7 @@ func (m *UserRepo) dtoToEntity(dto userDTO) entity.User {
 		ID:           dto.ID.Hex(),
 		Username:     dto.Username,
 		Email:        dto.Email,
+		Sub:          dto.Sub,
 		AccessLevel:  entity.AccessLevel(dto.AccessLevel),
 		CreationDate: dto.CreationDate,
 		SSHKey: entity.SSHKey{

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -89,7 +89,8 @@ func TestInteractor_Create(t *testing.T) {
 	const (
 		id            = "user.1234"
 		email         = "user@email.com"
-		username      = "john.doe"
+		username      = "user"
+		sub           = "f6717d2b-ac1f-40da-ade6-00037512933b"
 		accessLevel   = entity.AccessLevelAdmin
 		publicSSHKey  = "test-ssh-key-public"
 		privateSSHKey = "test-ssh-key-private"
@@ -107,6 +108,7 @@ func TestInteractor_Create(t *testing.T) {
 	u := entity.User{
 		Username:     username,
 		Email:        email,
+		Sub:          sub,
 		AccessLevel:  accessLevel,
 		SSHKey:       sshKey,
 		CreationDate: now,
@@ -115,6 +117,7 @@ func TestInteractor_Create(t *testing.T) {
 	expectedUser := entity.User{
 		ID:           id,
 		Username:     username,
+		Sub:          sub,
 		Email:        email,
 		AccessLevel:  accessLevel,
 		SSHKey:       sshKey,
@@ -123,6 +126,7 @@ func TestInteractor_Create(t *testing.T) {
 
 	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(entity.User{}, entity.ErrUserNotFound)
 	s.mocks.repo.EXPECT().GetByEmail(ctx, email).Return(entity.User{}, entity.ErrUserNotFound)
+	s.mocks.repo.EXPECT().GetBySub(ctx, sub).Return(entity.User{}, entity.ErrUserNotFound)
 	s.mocks.clock.EXPECT().Now().Return(now)
 	s.mocks.sshGenerator.EXPECT().NewKeys().Return(sshKey, nil)
 	s.mocks.repo.EXPECT().Create(ctx, u).Return(id, nil)
@@ -130,7 +134,7 @@ func TestInteractor_Create(t *testing.T) {
 	s.mocks.k8sClientMock.EXPECT().CreateUserSSHKeySecret(ctx, u, publicSSHKey, privateSSHKey)
 	s.mocks.k8sClientMock.EXPECT().CreateUserServiceAccount(ctx, u.UsernameSlug())
 
-	createdUser, err := s.interactor.Create(ctx, email, username, accessLevel)
+	createdUser, err := s.interactor.Create(ctx, email, sub, accessLevel)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedUser, createdUser)
@@ -142,16 +146,17 @@ func TestInteractor_Create_UserDuplEmail(t *testing.T) {
 
 	const (
 		email       = "user@email.com"
-		username    = "john"
+		user        = "user"
+		sub         = "f6717d2b-ac1f-40da-ade6-00037512933b"
 		accessLevel = entity.AccessLevelAdmin
 	)
 
 	ctx := context.Background()
 
-	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(entity.User{}, entity.ErrUserNotFound)
+	s.mocks.repo.EXPECT().GetByUsername(ctx, user).Return(entity.User{}, entity.ErrUserNotFound)
 	s.mocks.repo.EXPECT().GetByEmail(ctx, email).Return(entity.User{}, nil)
 
-	createdUser, err := s.interactor.Create(ctx, email, username, accessLevel)
+	createdUser, err := s.interactor.Create(ctx, email, sub, accessLevel)
 	assert.DeepEqual(t, entity.User{}, createdUser)
 	assert.ErrorIs(t, err, entity.ErrDuplicatedUser)
 }
@@ -162,15 +167,38 @@ func TestInteractor_Create_UserDuplUsername(t *testing.T) {
 
 	const (
 		email       = "user@email.com"
-		username    = "john"
+		user        = "user"
+		sub         = "f6717d2b-ac1f-40da-ade6-00037512933b"
 		accessLevel = entity.AccessLevelAdmin
 	)
 
 	ctx := context.Background()
 
-	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(entity.User{}, nil)
+	s.mocks.repo.EXPECT().GetByUsername(ctx, user).Return(entity.User{}, nil)
 
-	createdUser, err := s.interactor.Create(ctx, email, username, accessLevel)
+	createdUser, err := s.interactor.Create(ctx, email, sub, accessLevel)
+	assert.DeepEqual(t, entity.User{}, createdUser)
+	assert.ErrorIs(t, err, entity.ErrDuplicatedUser)
+}
+
+func TestInteractor_Create_UserDuplSub(t *testing.T) {
+	s := newUserSuite(t, nil)
+	defer s.ctrl.Finish()
+
+	const (
+		email       = "user@email.com"
+		user        = "user"
+		sub         = "f6717d2b-ac1f-40da-ade6-00037512933b"
+		accessLevel = entity.AccessLevelAdmin
+	)
+
+	ctx := context.Background()
+
+	s.mocks.repo.EXPECT().GetByUsername(ctx, user).Return(entity.User{}, entity.ErrUserNotFound)
+	s.mocks.repo.EXPECT().GetByEmail(ctx, email).Return(entity.User{}, entity.ErrUserNotFound)
+	s.mocks.repo.EXPECT().GetBySub(ctx, sub).Return(entity.User{}, nil)
+
+	createdUser, err := s.interactor.Create(ctx, email, sub, accessLevel)
 	assert.DeepEqual(t, entity.User{}, createdUser)
 	assert.ErrorIs(t, err, entity.ErrDuplicatedUser)
 }

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -14,6 +14,7 @@ type Repository interface {
 	Get(ctx context.Context, id string) (entity.User, error)
 	GetByUsername(ctx context.Context, username string) (entity.User, error)
 	GetByEmail(ctx context.Context, email string) (entity.User, error)
+	GetBySub(ctx context.Context, sub string) (entity.User, error)
 	Create(ctx context.Context, user entity.User) (string, error)
 	UpdateAccessLevel(ctx context.Context, userIDs []string, level entity.AccessLevel) error
 	UpdateSSHKey(ctx context.Context, username string, SSHKey entity.SSHKey) error
@@ -26,7 +27,7 @@ type Repository interface {
 
 // UseCase interface to manage all operations related with users.
 type UseCase interface {
-	Create(ctx context.Context, email, username string, accessLevel entity.AccessLevel) (entity.User, error)
+	Create(ctx context.Context, email, sub string, accessLevel entity.AccessLevel) (entity.User, error)
 	CreateAdminUser(username, email string) error
 	UpdateAccessLevel(ctx context.Context, userIDs []string, level entity.AccessLevel) ([]entity.User, error)
 	FindAll(ctx context.Context) ([]entity.User, error)

--- a/app/api/usecase/user/mocks_interface.go
+++ b/app/api/usecase/user/mocks_interface.go
@@ -124,6 +124,21 @@ func (mr *MockRepositoryMockRecorder) GetByEmail(ctx, email interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByEmail", reflect.TypeOf((*MockRepository)(nil).GetByEmail), ctx, email)
 }
 
+// GetBySub mocks base method.
+func (m *MockRepository) GetBySub(ctx context.Context, sub string) (entity.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySub", ctx, sub)
+	ret0, _ := ret[0].(entity.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBySub indicates an expected call of GetBySub.
+func (mr *MockRepositoryMockRecorder) GetBySub(ctx, sub interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySub", reflect.TypeOf((*MockRepository)(nil).GetBySub), ctx, sub)
+}
+
 // GetByUsername mocks base method.
 func (m *MockRepository) GetByUsername(ctx context.Context, username string) (entity.User, error) {
 	m.ctrl.T.Helper()
@@ -248,18 +263,18 @@ func (mr *MockUseCaseMockRecorder) AreToolsRunning(ctx, username interface{}) *g
 }
 
 // Create mocks base method.
-func (m *MockUseCase) Create(ctx context.Context, email, username string, accessLevel entity.AccessLevel) (entity.User, error) {
+func (m *MockUseCase) Create(ctx context.Context, email, sub string, accessLevel entity.AccessLevel) (entity.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, email, username, accessLevel)
+	ret := m.ctrl.Call(m, "Create", ctx, email, sub, accessLevel)
 	ret0, _ := ret[0].(entity.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockUseCaseMockRecorder) Create(ctx, email, username, accessLevel interface{}) *gomock.Call {
+func (mr *MockUseCaseMockRecorder) Create(ctx, email, sub, accessLevel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUseCase)(nil).Create), ctx, email, username, accessLevel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUseCase)(nil).Create), ctx, email, sub, accessLevel)
 }
 
 // CreateAdminUser mocks base method.


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OauthProxy send Keycloak unique identifier to KDL. Store in Uset entity in case we need this sub to match user against other services using oicd auth.

## PR Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Please check if your PR fulfills the following requirements:

- [X] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [X] I have updated the documentation accordingly.
- [X] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
