### PR TITLE
fix(project-operator): fix filebrowser permissions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,27 @@ repos:
     - id: check-symlinks
     - id: end-of-file-fixer
     - id: check-yaml
+      exclude: ^(project-operator|user-tools-operator)/
+
 - repo: https://github.com/zricethezav/gitleaks
   rev: v8.21.1
   hooks:
     - id: gitleaks
+
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1
   hooks:
     - id: golangci-lint
       args: ['--config', '.github/.golangci.yml', 'app/api/...', 'cleaner/...', 'repo-cloner/...']
+
+- repo: https://github.com/gruntwork-io/pre-commit
+  rev: v0.1.15
+  hooks:
+    - id: helmlint
+      files: ^(project-operator|user-tools-operator)/
+
+- repo: https://github.com/norwoodj/helm-docs
+  rev: v1.10.0
+  hooks:
+    - id: helm-docs
+      files: ^(project-operator|user-tools-operator)/.*(README\.md\.gotmpl|(Chart|requirements|values)\.yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v5.0.0
   hooks:
     - id: check-added-large-files
     - id: trailing-whitespace
@@ -11,7 +11,7 @@ repos:
       exclude: ^(project-operator|user-tools-operator)/
 
 - repo: https://github.com/zricethezav/gitleaks
-  rev: v8.21.1
+  rev: v8.21.2
   hooks:
     - id: gitleaks
 
@@ -22,13 +22,13 @@ repos:
       args: ['--config', '.github/.golangci.yml', 'app/api/...', 'cleaner/...', 'repo-cloner/...']
 
 - repo: https://github.com/gruntwork-io/pre-commit
-  rev: v0.1.15
+  rev: v0.1.24
   hooks:
     - id: helmlint
       files: ^(project-operator|user-tools-operator)/
 
 - repo: https://github.com/norwoodj/helm-docs
-  rev: v1.10.0
+  rev: v1.14.2
   hooks:
     - id: helm-docs
       files: ^(project-operator|user-tools-operator)/.*(README\.md\.gotmpl|(Chart|requirements|values)\.yaml)$

--- a/project-operator/helm-charts/kdlproject/templates/filebrowser/configmap.yml
+++ b/project-operator/helm-charts/kdlproject/templates/filebrowser/configmap.yml
@@ -20,6 +20,6 @@ data:
     /filebrowser config init
     /filebrowser config set --auth.method=noauth
     /filebrowser users add kdladmin not_used_pass --perm.admin=false --perm.download=true --perm.create=true \
-        --perm.delete=true --perm.execute=false --perm.modify=false --perm.rename=true --perm.share=false \
+        --perm.delete=true --perm.execute=false --perm.modify=true --perm.rename=true --perm.share=false \
         --lockPassword=true
     /filebrowser

--- a/project-operator/helm-charts/kdlproject/templates/filebrowser/deployment.yml
+++ b/project-operator/helm-charts/kdlproject/templates/filebrowser/deployment.yml
@@ -1,8 +1,4 @@
-{{ if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
-  {{ else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
-apiVersion: extensions/v1beta1
-  {{ end }}
 kind: Deployment
 metadata:
   name: {{ .Values.projectId }}-filebrowser
@@ -18,6 +14,10 @@ spec:
       labels:
         app: {{ .Values.projectId }}-filebrowser
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
     {{- with .Values.filebrowser.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -34,6 +34,10 @@ spec:
         - name: filebrowser
           image: {{ .Values.filebrowser.image.repository }}:{{ .Values.filebrowser.image.tag }}
           imagePullPolicy: {{ .Values.filebrowser.image.pullPolicy }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
           command:
             - /bin/sh
           args:
@@ -57,9 +61,9 @@ spec:
             periodSeconds: 60
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- range .Values.imagePullSecrets  }}
+        {{- range .Values.imagePullSecrets }}
         - name: {{ . }}
-      {{- end }}
+        {{- end }}
       {{- end }}
       volumes:
         - name: filebrowser-config

--- a/project-operator/helm-charts/kdlproject/templates/filebrowser/deployment.yml
+++ b/project-operator/helm-charts/kdlproject/templates/filebrowser/deployment.yml
@@ -14,10 +14,6 @@ spec:
       labels:
         app: {{ .Values.projectId }}-filebrowser
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
     {{- with .Values.filebrowser.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -34,10 +30,6 @@ spec:
         - name: filebrowser
           image: {{ .Values.filebrowser.image.repository }}:{{ .Values.filebrowser.image.tag }}
           imagePullPolicy: {{ .Values.filebrowser.image.pullPolicy }}
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
           command:
             - /bin/sh
           args:


### PR DESCRIPTION
## Motivation and Context

Added SecurityContext configuration to the Filebrowser deployment template to enforce user and group permissions (UID/GID: 1000). This change ensures proper filesystem access permissions between Filebrowser and the `sharedVolume`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [X] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Filebrowser deployment runs with root privileges (UID/GID: 0), which is not aligned with security best practices and could pose potential security risks. Running as root provides unnecessary elevated permissions and doesn't follow the principle of least privilege.

## What is the new behavior?

The deployment now runs with a non-root user (UID/GID: 1000) through SecurityContext configurations at both pod and container levels, ensuring proper file permissions and access to wirte on `sharedVolume`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
