### PR TITLE
fix: [KDL6-95] increase timeout in request longer than 10 seconds

### DIFF
--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -139,9 +139,9 @@ func startHTTPServer(
 	server := &http.Server{
 		Addr:         ":" + port,
 		Handler:      nil,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  15 * time.Second,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  30 * time.Second,
 	}
 
 	err := server.ListenAndServe()

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -253,7 +253,6 @@ func (r *projectResolver) NeedAccess(ctx context.Context, obj *entity.Project) (
 
 // Me is the resolver for the me field.
 func (r *queryResolver) Me(ctx context.Context) (*entity.User, error) {
-	time.Sleep(11 * time.Second)
 	loggedUser, err := r.getLoggedUser(ctx)
 	if err != nil {
 		return nil, err

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -253,6 +253,7 @@ func (r *projectResolver) NeedAccess(ctx context.Context, obj *entity.Project) (
 
 // Me is the resolver for the me field.
 func (r *queryResolver) Me(ctx context.Context) (*entity.User, error) {
+	time.Sleep(11 * time.Second)
 	loggedUser, err := r.getLoggedUser(ctx)
 	if err != nil {
 		return nil, err

--- a/hack/scripts/helmfile/values/kdl-local/values.yaml.gotmpl
+++ b/hack/scripts/helmfile/values/kdl-local/values.yaml.gotmpl
@@ -212,9 +212,10 @@ oauth2proxy:
 
     configFile: |-
       upstreams=["http://kdl-local-server:80/", "http://127.0.0.1:9000/mlflow/", "http://127.0.0.1:9000/filebrowser/", "http://127.0.0.1:9000/kg/"]
+      silence_ping_logging=true
       cookie_domains=["kdlapp.{{ requiredEnv "DOMAIN" }}", "keycloak.{{ requiredEnv "DOMAIN" }}"]
       cookie_samesite="lax"
-      cookie_secure=true
+      cookie_secure=false
       email_domains="*"
       errors_to_info_log=true
       http_address="https://kdlapp.{{ requiredEnv "DOMAIN" }}/"


### PR DESCRIPTION
## Motivation and Context

When starting user tools, frontend waits for response from server. If the request takes a long time, it returns 502. It is due to timeout set in http servers, so increasing a bit the numbers.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://intelygenz.atlassian.net/browse/KDL6-95

## PR Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Please check if your PR fulfills the following requirements:

- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [X] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
