### PR TITLE
feat(API): [KDL6-276] update CR on configmap change

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -223,6 +223,7 @@ issues:
         - gochecknoglobals
         - gosec
         - mnd
+        - funlen # it's not common to fragment test functions
     # https://github.com/go-critic/go-critic/issues/926
     - linters:
         - gocritic

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -224,6 +224,7 @@ issues:
         - gosec
         - mnd
         - funlen # it's not common to fragment test functions
+        - dupl # tests are repetitive by nature
     # https://github.com/go-critic/go-critic/issues/926
     - linters:
         - gocritic

--- a/app/api/entity/capabilities.go
+++ b/app/api/entity/capabilities.go
@@ -157,7 +157,7 @@ func checkTolerationSeconds(toleration map[string]interface{}) error {
 
 	if ok {
 		switch seconds.(type) {
-		case int, int32, int64:
+		case int, int32, int64, float64:
 		default:
 			return wrapErrWithValue(ErrCapabilitiesInvalidSeconds, fmt.Sprintf("%v", seconds))
 		}

--- a/app/api/infrastructure/k8s/error.go
+++ b/app/api/infrastructure/k8s/error.go
@@ -4,7 +4,6 @@ import "errors"
 
 var errCRDNoMetadata = errors.New("CRD does not have a 'metadata' field")
 var errCRDNoSpec = errors.New("CRD does not have a 'spec' field")
-var errCDRNoSpecUsername = errors.New("CRD does not have a 'spec.username' field")
 var errCRDNoSpecMlflow = errors.New("CRD does not have a 'spec.mlflow' field")
 var errCRDNoSpecMlflowEnv = errors.New("CRD does not have a 'spec.mlflow.env' field")
 var errCRDNoSpecFilebrowser = errors.New("CRD does not have a 'spec.filebrowser' field")
@@ -13,4 +12,5 @@ var errCRDNoSpecVscodeRuntime = errors.New("CRD does not have a 'spec.vscodeRunt
 var errCRDNoSpecVscodeRuntimeEnv = errors.New("CRD does not have a 'spec.vscodeRuntime.env' field")
 var errCRDNoSpecVscodeRuntimeImage = errors.New("CRD does not have a 'spec.vscodeRuntime.image' field")
 var errCRDNoSpecPodLabels = errors.New("CRD does not have a 'spec.podLabels' field")
-var errCRDCantEncodeInputData = errors.New("can't encode input data")
+var errCRDCantEncodeInputData = errors.New("can't encode input data for CR")
+var errCRDCantDecodeInputData = errors.New("can't decode input data from CR")

--- a/app/api/infrastructure/k8s/error.go
+++ b/app/api/infrastructure/k8s/error.go
@@ -13,3 +13,4 @@ var errCRDNoSpecVscodeRuntime = errors.New("CRD does not have a 'spec.vscodeRunt
 var errCRDNoSpecVscodeRuntimeEnv = errors.New("CRD does not have a 'spec.vscodeRuntime.env' field")
 var errCRDNoSpecVscodeRuntimeImage = errors.New("CRD does not have a 'spec.vscodeRuntime.image' field")
 var errCRDNoSpecPodLabels = errors.New("CRD does not have a 'spec.podLabels' field")
+var errCRDCantEncodeInputData = errors.New("can't encode input data")

--- a/app/api/infrastructure/k8s/interface.go
+++ b/app/api/infrastructure/k8s/interface.go
@@ -18,7 +18,7 @@ type ClientInterface interface {
 	CreateSecret(ctx context.Context, name string, values, labels map[string]string) error
 	UpdateSecret(ctx context.Context, name string, values, labels map[string]string) error
 	GetSecret(ctx context.Context, name string) (map[string][]byte, error)
-	CreateKDLUserToolsCR(ctx context.Context, username string, data UserToolsData) error
+	CreateKDLUserToolsCR(ctx context.Context, data UserToolsData) error
 	DeleteUserToolsCR(ctx context.Context, username string) error
 	UpdateKDLUserToolsCR(ctx context.Context, resourceName string, data UserToolsData, crd *map[string]interface{}) error
 	ListKDLUserToolsCR(ctx context.Context) ([]unstructured.Unstructured, error)

--- a/app/api/infrastructure/k8s/interface.go
+++ b/app/api/infrastructure/k8s/interface.go
@@ -20,7 +20,7 @@ type ClientInterface interface {
 	GetSecret(ctx context.Context, name string) (map[string][]byte, error)
 	CreateKDLUserToolsCR(ctx context.Context, data UserToolsData) error
 	DeleteUserToolsCR(ctx context.Context, username string) error
-	UpdateKDLUserToolsCR(ctx context.Context, resourceName string, data UserToolsData, crd *map[string]interface{}) error
+	UpdateKDLUserToolsCR(ctx context.Context, resourceName string, crd *map[string]interface{}) error
 	ListKDLUserToolsCR(ctx context.Context) ([]unstructured.Unstructured, error)
 	GetKDLUserToolsCR(ctx context.Context, username string) (*unstructured.Unstructured, error)
 	IsUserToolPODRunning(ctx context.Context, username string) (bool, error)

--- a/app/api/infrastructure/k8s/kdlproject.go
+++ b/app/api/infrastructure/k8s/kdlproject.go
@@ -28,6 +28,30 @@ func (k *Client) ProjectDataToMap(data ProjectData) (map[string]string, error) {
 	}, nil
 }
 
+func (k *Client) MapToProjectData(data map[string]interface{}) (ProjectData, error) {
+	minioAccessKeyJSON, ok := data["minioAccessKey"].(string)
+	if !ok {
+		return ProjectData{}, errCRDCantDecodeInputData
+	}
+
+	var minioAccessKey entity.MinioAccessKey
+
+	err := json.Unmarshal([]byte(minioAccessKeyJSON), &minioAccessKey)
+	if err != nil {
+		return ProjectData{}, err
+	}
+
+	projectID, ok := data["projectId"].(string)
+	if !ok {
+		return ProjectData{}, errCRDCantDecodeInputData
+	}
+
+	return ProjectData{
+		ProjectID:      projectID,
+		MinioAccessKey: minioAccessKey,
+	}, nil
+}
+
 func (k *Client) GetConfigMapTemplateNameKDLProject() string {
 	return k.cfg.ReleaseName + "-server-project-template"
 }
@@ -167,13 +191,32 @@ func (k *Client) GetKDLProjectCR(ctx context.Context, name string) (*unstructure
 }
 
 func (k *Client) UpdateKDLProjectsCR(ctx context.Context, projectID string, crd *map[string]interface{}) error {
-	// update the CRD object with correct values
-	data := ProjectData{
-		ProjectID: projectID,
-		// FUTURE: add minio credentials here
+	k.logger.Info("Updating kdl project", "projectName", projectID)
+
+	// Get existing CR
+	existingKDLProject, err := k.GetKDLProjectCR(ctx, projectID)
+	if err != nil {
+		return err
 	}
 
-	crdUpdated, err := k.updateKDLProjectTemplate(data, crd)
+	// Recover the input data from the existing CR
+	existingSpec, _, err := unstructured.NestedMap(existingKDLProject.Object, "spec")
+	if err != nil {
+		return errCRDCantDecodeInputData
+	}
+
+	inputDataMap, ok := existingSpec["inputData"].(map[string]interface{})
+	if !ok {
+		return errCRDCantDecodeInputData
+	}
+
+	inputData, err := k.MapToProjectData(inputDataMap)
+	if err != nil {
+		return errCRDCantDecodeInputData
+	}
+
+	// Re-apply the input data with the updated template
+	crdUpdated, err := k.updateKDLProjectTemplate(inputData, crd)
 	if err != nil {
 		return err
 	}
@@ -184,23 +227,16 @@ func (k *Client) UpdateKDLProjectsCR(ctx context.Context, projectID string, crd 
 		return errCRDNoSpec
 	}
 
-	existingKDLProject, err := k.GetKDLProjectCR(ctx, data.ProjectID)
-	if err != nil {
-		return err
-	}
-
 	existingKDLProject.Object["spec"] = specValue
 
 	// CRD object is now updated and ready to be created
-	k.logger.Info("Updating kdl project", "projectName", data.ProjectID)
-
 	_, err = k.kdlProjectRes.Namespace(k.cfg.Kubernetes.Namespace).Update(ctx, existingKDLProject, metav1.UpdateOptions{})
 	if err != nil {
-		k.logger.Error(err, "Error updating KDL Project CR in k8s", "projectName", data.ProjectID)
+		k.logger.Error(err, "Error updating KDL Project CR in k8s", "projectName", projectID)
 		return err
 	}
 
-	k.logger.Info("Updated kdl project", "projectName", data.ProjectID)
+	k.logger.Info("Updated kdl project", "projectName", projectID)
 
 	return nil
 }

--- a/app/api/infrastructure/k8s/kdlproject_test.go
+++ b/app/api/infrastructure/k8s/kdlproject_test.go
@@ -272,6 +272,13 @@ func (s *testSuite) TestUpdateKDLProjectsCR() {
 	// Update the CR
 	crd := map[string]interface{}{
 		"spec": map[string]interface{}{
+			"inputData": map[string]interface{}{
+				"projectId": "my-demo-projectId",
+				"minioAccessKey": map[string]interface{}{
+					"AccessKey": "my-demo-accessKey",
+					"SecretKey": "my-demo-secretKey",
+				},
+			},
 			"projectId": "my-demo-projectId",
 			"mlflow": map[string]interface{}{
 				"env": map[string]interface{}{

--- a/app/api/infrastructure/k8s/kdlproject_test.go
+++ b/app/api/infrastructure/k8s/kdlproject_test.go
@@ -81,6 +81,13 @@ func (s *testSuite) TestCreateKDLProjectCR_and_DeleteKDLProjectCR() {
 	s.Require().Equal(projectMinioAccessKey, filebrowserEnv["AWS_S3_ACCESS_KEY_ID"])
 	s.Require().Equal(projectMinioSecretKey, filebrowserEnv["AWS_S3_SECRET_ACCESS_KEY"])
 
+	// Check the input data itself is stored as well
+	minioAccessKeyJSON := "{\"AccessKey\":\"project-test-project-id\",\"SecretKey\":\"testproject123\"}"
+	inputData, _ := spec["inputData"].(map[string]interface{})
+	inputProjectID, _ := inputData["projectId"].(string)
+	s.Require().Equal(projectID, inputProjectID)
+	s.Require().Equal(minioAccessKeyJSON, inputData["minioAccessKey"])
+
 	// Delete the CR
 	err = s.Client.DeleteKDLProjectCR(context.Background(), projectID)
 	s.Require().NoError(err)

--- a/app/api/infrastructure/k8s/kdlusertools.go
+++ b/app/api/infrastructure/k8s/kdlusertools.go
@@ -373,7 +373,7 @@ func (k *Client) GetKDLUserToolsCR(ctx context.Context, resourceName string) (*u
 	return object, nil
 }
 
-func (k *Client) UpdateKDLUserToolsCR(ctx context.Context, resourceName string, _ UserToolsData, crd *map[string]interface{}) error {
+func (k *Client) UpdateKDLUserToolsCR(ctx context.Context, resourceName string, crd *map[string]interface{}) error {
 	// CRD object is now updated and ready to be created
 	k.logger.Info("Updating KDL User Tools CR in k8s", "resourceName", resourceName)
 

--- a/app/api/infrastructure/k8s/kdlusertools_test.go
+++ b/app/api/infrastructure/k8s/kdlusertools_test.go
@@ -578,7 +578,7 @@ func (s *testSuite) TestUpdateKDLUserToolsCR() {
 			"name": "new-res-name",
 		},
 	}
-	err = s.Client.UpdateKDLUserToolsCR(context.Background(), resName, userToolsData, &crd)
+	err = s.Client.UpdateKDLUserToolsCR(context.Background(), resName, &crd)
 	s.Require().NoError(err)
 
 	// Delete the CR

--- a/app/api/infrastructure/k8s/kdlusertools_test.go
+++ b/app/api/infrastructure/k8s/kdlusertools_test.go
@@ -4,6 +4,7 @@ package k8s_test
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/konstellation-io/kdl-server/app/api/entity"
@@ -134,6 +135,30 @@ func (s *testSuite) TestCreateKDLUserToolsCR_and_DeleteUserToolsCR() {
 	s.Require().Equal("value1", toleration["value"])
 	s.Require().Equal("NoExecute", toleration["effect"])
 	s.Require().Equal(int64(100), toleration["tolerationSeconds"])
+
+	// Check the input data itself is stored as well
+	inputData, _ := spec["inputData"].(map[string]interface{})
+	inputUserName, _ := inputData["username"].(string)
+	inputSlugUserName, _ := inputData["slugUsername"].(string)
+	inputRuntimeID, _ := inputData["runtimeID"].(string)
+	inputRuntimeImage, _ := inputData["runtimeImage"].(string)
+	inputRuntimeTag, _ := inputData["runtimeTag"].(string)
+
+	s.Require().Equal(username, inputUserName)
+	s.Require().Equal(slugUsername, inputSlugUserName)
+	s.Require().Equal(runtimeID, inputRuntimeID)
+	s.Require().Equal(runtimeImage, inputRuntimeImage)
+	s.Require().Equal(runtimeTag, inputRuntimeTag)
+
+	var decodedMinioAccessKey entity.MinioAccessKey
+
+	inputMinioAccessKey, _ := inputData["minioAccessKey"].(string)
+
+	err = json.Unmarshal([]byte(inputMinioAccessKey), &decodedMinioAccessKey)
+	s.Require().NoError(err)
+
+	s.Require().Equal(minioAccessKey, decodedMinioAccessKey.AccessKey)
+	s.Require().Equal(minioSecretKey, decodedMinioAccessKey.SecretKey)
 
 	// Delete the CR
 	// create go routine to cancel the context in 5 seconds. Risk of flaky test

--- a/app/api/infrastructure/k8s/kdlusertools_test.go
+++ b/app/api/infrastructure/k8s/kdlusertools_test.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	username                         = "test.username"
+	slugUsername                     = "test-username"
 	resName                          = "usertools-test-username"
 	minioAccessKey                   = "user-test-username"
 	minioSecretKey                   = "username123"
@@ -24,11 +25,15 @@ const (
 )
 
 var userToolsData = k8s.UserToolsData{
+	Username:     username,
+	SlugUsername: slugUsername,
 	RuntimeID:    runtimeID,
 	RuntimeImage: runtimeImage,
 	RuntimeTag:   runtimeTag,
 }
 var dataWithCapabilities = k8s.UserToolsData{
+	Username:     username,
+	SlugUsername: slugUsername,
 	RuntimeID:    runtimeID,
 	RuntimeImage: runtimeImage,
 	RuntimeTag:   runtimeTag,
@@ -101,7 +106,7 @@ func (s *testSuite) TestCreateKDLUserToolsCR_and_DeleteUserToolsCR() {
 		cancelCreateUserToolCR()
 	}()
 
-	err := s.Client.CreateKDLUserToolsCR(ctx, username, dataWithCapabilities)
+	err := s.Client.CreateKDLUserToolsCR(ctx, dataWithCapabilities)
 	s.Require().NoError(err)
 
 	// Retrieve the Custom Resource
@@ -143,7 +148,7 @@ func (s *testSuite) TestCreateKDLUserToolsCR_and_DeleteUserToolsCR() {
 }
 
 func (s *testSuite) TestCreateKDLUserToolsCR_NoConfigMap() {
-	err := s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err := s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -158,7 +163,7 @@ func (s *testSuite) TestCreateKDLUserToolsCR_ConfigMapWithoutTemplate() {
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -180,7 +185,7 @@ kind: KDLUserTools
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -205,7 +210,7 @@ metadata:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -232,7 +237,7 @@ metadata:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -262,7 +267,7 @@ spec:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -293,7 +298,7 @@ spec:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -328,7 +333,7 @@ spec:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, dataWithCapabilities)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), dataWithCapabilities)
 	s.Require().Error(err)
 }
 
@@ -364,7 +369,7 @@ spec:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, dataWithCapabilities)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), dataWithCapabilities)
 	s.Require().Error(err)
 }
 
@@ -401,7 +406,7 @@ spec:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, dataWithCapabilities)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), dataWithCapabilities)
 	s.Require().Error(err)
 }
 
@@ -439,7 +444,7 @@ spec:
 	)
 	s.Require().NoError(err)
 
-	err = s.Client.CreateKDLUserToolsCR(context.Background(), username, userToolsData)
+	err = s.Client.CreateKDLUserToolsCR(context.Background(), userToolsData)
 	s.Require().Error(err)
 }
 
@@ -452,7 +457,7 @@ func (s *testSuite) TestListKDLUserToolsCR() {
 		cancelCreateUserToolCR()
 	}()
 
-	err := s.Client.CreateKDLUserToolsCR(ctx, username, dataWithCapabilities)
+	err := s.Client.CreateKDLUserToolsCR(ctx, dataWithCapabilities)
 	s.Require().NoError(err)
 
 	// List the CR
@@ -488,7 +493,7 @@ func (s *testSuite) TestGetKDLUserToolsCR() {
 		cancelCreateUserToolCR()
 	}()
 
-	err := s.Client.CreateKDLUserToolsCR(ctx, username, dataWithCapabilities)
+	err := s.Client.CreateKDLUserToolsCR(ctx, dataWithCapabilities)
 	s.Require().NoError(err)
 
 	// Get the CR
@@ -524,7 +529,7 @@ func (s *testSuite) TestUpdateKDLUserToolsCR() {
 		cancelCreateUserToolCR()
 	}()
 
-	err := s.Client.CreateKDLUserToolsCR(ctx, username, dataWithCapabilities)
+	err := s.Client.CreateKDLUserToolsCR(ctx, dataWithCapabilities)
 	s.Require().NoError(err)
 
 	// Update the CR

--- a/app/api/infrastructure/k8s/mocks_interface.go
+++ b/app/api/infrastructure/k8s/mocks_interface.go
@@ -82,17 +82,17 @@ func (mr *MockClientInterfaceMockRecorder) CreateKDLProjectCR(ctx, data interfac
 }
 
 // CreateKDLUserToolsCR mocks base method.
-func (m *MockClientInterface) CreateKDLUserToolsCR(ctx context.Context, username string, data UserToolsData) error {
+func (m *MockClientInterface) CreateKDLUserToolsCR(ctx context.Context, data UserToolsData) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateKDLUserToolsCR", ctx, username, data)
+	ret := m.ctrl.Call(m, "CreateKDLUserToolsCR", ctx, data)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateKDLUserToolsCR indicates an expected call of CreateKDLUserToolsCR.
-func (mr *MockClientInterfaceMockRecorder) CreateKDLUserToolsCR(ctx, username, data interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) CreateKDLUserToolsCR(ctx, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKDLUserToolsCR", reflect.TypeOf((*MockClientInterface)(nil).CreateKDLUserToolsCR), ctx, username, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKDLUserToolsCR", reflect.TypeOf((*MockClientInterface)(nil).CreateKDLUserToolsCR), ctx, data)
 }
 
 // CreateSecret mocks base method.

--- a/app/api/infrastructure/k8s/mocks_interface.go
+++ b/app/api/infrastructure/k8s/mocks_interface.go
@@ -418,17 +418,17 @@ func (mr *MockClientInterfaceMockRecorder) UpdateKDLProjectsCR(ctx, projectID, c
 }
 
 // UpdateKDLUserToolsCR mocks base method.
-func (m *MockClientInterface) UpdateKDLUserToolsCR(ctx context.Context, resourceName string, data UserToolsData, crd *map[string]interface{}) error {
+func (m *MockClientInterface) UpdateKDLUserToolsCR(ctx context.Context, resourceName string, crd *map[string]interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateKDLUserToolsCR", ctx, resourceName, data, crd)
+	ret := m.ctrl.Call(m, "UpdateKDLUserToolsCR", ctx, resourceName, crd)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateKDLUserToolsCR indicates an expected call of UpdateKDLUserToolsCR.
-func (mr *MockClientInterfaceMockRecorder) UpdateKDLUserToolsCR(ctx, resourceName, data, crd interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) UpdateKDLUserToolsCR(ctx, resourceName, crd interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKDLUserToolsCR", reflect.TypeOf((*MockClientInterface)(nil).UpdateKDLUserToolsCR), ctx, resourceName, data, crd)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKDLUserToolsCR", reflect.TypeOf((*MockClientInterface)(nil).UpdateKDLUserToolsCR), ctx, resourceName, crd)
 }
 
 // UpdateSecret mocks base method.

--- a/app/api/infrastructure/k8s/suite_test.go
+++ b/app/api/infrastructure/k8s/suite_test.go
@@ -52,87 +52,88 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, new(testSuite))
 }
 
-func (s *testSuite) defineCRDKDLUserTools(restcfg *rest.Config) {
-	// Create a clientset for CRD operations
-	apiExtensionsClient, err := apiextensionsclient.NewForConfig(restcfg)
-	s.Require().NoError(err)
-
-	// Define the CRD for KDLUserTools
-	preserve := true
-	crdKdlUserTools := &apiextensionsv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kdlusertools.kdl.konstellation.io", // Format: plural.group
+var preserve = true
+var crdKdlUserTools = &apiextensionsv1.CustomResourceDefinition{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "kdlusertools.kdl.konstellation.io", // Format: plural.group
+	},
+	Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+		Group: "kdl.konstellation.io",
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "kdlusertools",
+			Singular: "kdlusertool",
+			Kind:     "KDLUserTools",
+			ListKind: "KDLUserToolsList",
 		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "kdl.konstellation.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Plural:   "kdlusertools",
-				Singular: "kdlusertool",
-				Kind:     "KDLUserTools",
-				ListKind: "KDLUserToolsList",
-			},
-			Scope: apiextensionsv1.NamespaceScoped,
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]apiextensionsv1.JSONSchemaProps{
-								"spec": {
-									Type: "object",
-									Properties: map[string]apiextensionsv1.JSONSchemaProps{
-										"username":     {Type: "string"},
-										"usernameSlug": {Type: "string"},
-										"vscodeRuntime": {
-											Type: "object",
-											Properties: map[string]apiextensionsv1.JSONSchemaProps{
-												"image": {
-													Type: "object",
-													Properties: map[string]apiextensionsv1.JSONSchemaProps{
-														"repository": {Type: "string"},
-														"tag":        {Type: "string"},
-													},
+		Scope: apiextensionsv1.NamespaceScoped,
+		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+			{
+				Name:    "v1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"inputData": {
+										Type: "object",
+										AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+											Schema: &apiextensionsv1.JSONSchemaProps{
+												Type: "string",
+											},
+										},
+									},
+									"username":     {Type: "string"},
+									"usernameSlug": {Type: "string"},
+									"vscodeRuntime": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"image": {
+												Type: "object",
+												Properties: map[string]apiextensionsv1.JSONSchemaProps{
+													"repository": {Type: "string"},
+													"tag":        {Type: "string"},
 												},
-												"env": {
-													Type:                   "object",
-													Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
-													XPreserveUnknownFields: &preserve,
+											},
+											"env": {
+												Type:                   "object",
+												Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+												XPreserveUnknownFields: &preserve,
+											},
+										},
+									},
+									"affinity": {
+										Type:                   "object",
+										Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+										XPreserveUnknownFields: &preserve,
+									},
+									"nodeSelector": {
+										Type:                   "object",
+										Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+										XPreserveUnknownFields: &preserve,
+									},
+									"tolerations": {
+										Type: "array",
+										Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+											Schema: &apiextensionsv1.JSONSchemaProps{
+												Type: "object",
+												Properties: map[string]apiextensionsv1.JSONSchemaProps{
+													"effect":            {Type: "string"},
+													"key":               {Type: "string"},
+													"operator":          {Type: "string"},
+													"tolerationSeconds": {Type: "integer"},
+													"value":             {Type: "string"},
 												},
 											},
 										},
-										"affinity": {
-											Type:                   "object",
-											Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
-											XPreserveUnknownFields: &preserve,
-										},
-										"nodeSelector": {
-											Type:                   "object",
-											Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
-											XPreserveUnknownFields: &preserve,
-										},
-										"tolerations": {
-											Type: "array",
-											Items: &apiextensionsv1.JSONSchemaPropsOrArray{
-												Schema: &apiextensionsv1.JSONSchemaProps{
-													Type: "object",
-													Properties: map[string]apiextensionsv1.JSONSchemaProps{
-														"effect":            {Type: "string"},
-														"key":               {Type: "string"},
-														"operator":          {Type: "string"},
-														"tolerationSeconds": {Type: "integer"},
-														"value":             {Type: "string"},
-													},
-												},
-											},
-										},
-										"podLabels": {
-											Type:                   "object",
-											Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
-											XPreserveUnknownFields: &preserve,
-										},
+									},
+									"podLabels": {
+										Type:                   "object",
+										Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+										XPreserveUnknownFields: &preserve,
 									},
 								},
 							},
@@ -141,79 +142,91 @@ func (s *testSuite) defineCRDKDLUserTools(restcfg *rest.Config) {
 				},
 			},
 		},
-	}
+	},
+}
+
+func (s *testSuite) defineCRDKDLUserTools(restcfg *rest.Config) {
+	// Create a clientset for CRD operations
+	apiExtensionsClient, err := apiextensionsclient.NewForConfig(restcfg)
+	s.Require().NoError(err)
 
 	// Create the CRD KDLUserTools in the cluster
 	_, err = apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crdKdlUserTools, metav1.CreateOptions{})
 	s.Require().NoError(err)
 }
 
-func (s *testSuite) defineCRDKDLProject(restcfg *rest.Config) {
-	// Create a clientset for CRD operations
-	apiExtensionsClient, err := apiextensionsclient.NewForConfig(restcfg)
-	s.Require().NoError(err)
-
-	preserve := true
-	// Define the CRD for KDLProject
-	crdKdlProject := &apiextensionsv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kdlprojects.kdl.konstellation.io", // Format: plural.group
+var crdKdlProject = &apiextensionsv1.CustomResourceDefinition{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "kdlprojects.kdl.konstellation.io", // Format: plural.group
+	},
+	Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+		Group: "kdl.konstellation.io",
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "kdlprojects",
+			Singular: "kdlproject",
+			Kind:     "KDLProject",
+			ListKind: "KDLProjectList",
 		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "kdl.konstellation.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Plural:   "kdlprojects",
-				Singular: "kdlproject",
-				Kind:     "KDLProject",
-				ListKind: "KDLProjectList",
-			},
-			Scope: apiextensionsv1.NamespaceScoped,
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]apiextensionsv1.JSONSchemaProps{
-								"spec": {
-									Type: "object",
-									Properties: map[string]apiextensionsv1.JSONSchemaProps{
-										"projectId": {
-											Type: "string",
-										},
-										"mlflow": {
-											Type: "object",
-											Properties: map[string]apiextensionsv1.JSONSchemaProps{
-												"env": {
-													Type:                   "object",
-													Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
-													XPreserveUnknownFields: &preserve,
-												},
-											},
-										},
-										"filebrowser": {
-											Type: "object",
-											Properties: map[string]apiextensionsv1.JSONSchemaProps{
-												"env": {
-													Type:                   "object",
-													Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
-													XPreserveUnknownFields: &preserve,
-												},
+		Scope: apiextensionsv1.NamespaceScoped,
+		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+			{
+				Name:    "v1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"inputData": {
+										Type: "object",
+										AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+											Schema: &apiextensionsv1.JSONSchemaProps{
+												Type: "string",
 											},
 										},
 									},
-									Required: []string{"projectId"},
+									"projectId": {
+										Type: "string",
+									},
+									"mlflow": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"env": {
+												Type:                   "object",
+												Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+												XPreserveUnknownFields: &preserve,
+											},
+										},
+									},
+									"filebrowser": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"env": {
+												Type:                   "object",
+												Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+												XPreserveUnknownFields: &preserve,
+											},
+										},
+									},
 								},
+								Required: []string{"projectId"},
 							},
-							Required: []string{"spec"},
 						},
+						Required: []string{"spec"},
 					},
 				},
 			},
 		},
-	}
+	},
+}
+
+func (s *testSuite) defineCRDKDLProject(restcfg *rest.Config) {
+	// Create a clientset for CRD operations
+	apiExtensionsClient, err := apiextensionsclient.NewForConfig(restcfg)
+	s.Require().NoError(err)
 
 	// Create the CRD KDLProject in the cluster
 	_, err = apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crdKdlProject, metav1.CreateOptions{})

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -21,9 +21,8 @@ import (
 )
 
 var (
-	ErrStopUserTools        = errors.New("cannot stop uninitialized user tools")
-	ErrUserToolsActive      = errors.New("it is not possible to regenerate SSH keys with the usertools active")
-	errCreatingKDLUserTools = errors.New("error creating CRD KDLUserTools ")
+	ErrStopUserTools   = errors.New("cannot stop uninitialized user tools")
+	ErrUserToolsActive = errors.New("it is not possible to regenerate SSH keys with the usertools active")
 )
 
 type Interactor struct {
@@ -436,48 +435,7 @@ func (i *Interactor) UpdateKDLUserTools(ctx context.Context) error {
 	for _, userTool := range kdlUserTools {
 		resourceName := userTool.GetName()
 
-		spec, ok := userTool.Object["spec"].(map[string]interface{})
-		if !ok {
-			i.logger.Error(errCreatingKDLUserTools, "Missing spec from KDL UserTools CR", "userToolName", userTool.GetName())
-			continue
-		}
-
-		podLabels, ok := spec["podLabels"].(map[string]interface{})
-		if !ok {
-			i.logger.Error(errCreatingKDLUserTools, "Missing spec.podLabels from KDL UserTools CR", "userToolName", userTool.GetName())
-			continue
-		}
-
-		runtimeID, ok := podLabels["runtimeId"].(string)
-		if !ok || runtimeID == "" {
-			i.logger.Error(errCreatingKDLUserTools, "Runtime ID provided is not valid, skipping user tools update", "userToolName", resourceName)
-			continue
-		}
-
-		capabilitiesID, ok := podLabels["capabilityId"].(string)
-		if !ok || capabilitiesID == "" {
-			i.logger.Error(errCreatingKDLUserTools, "Capability ID provided is not valid, skipping user tools update", "userToolName", resourceName)
-			continue
-		}
-
-		r, err := i.repoRuntimes.Get(ctx, runtimeID)
-		if err != nil {
-			i.logger.Error(err, "Error getting runtime", "runtimeID", runtimeID)
-			continue
-		}
-
-		var data = k8s.UserToolsData{}
-		data.RuntimeID = r.ID
-		data.RuntimeImage = r.DockerImage
-		data.RuntimeTag = r.DockerTag
-
-		data.Capabilities, err = i.repoCapabilities.Get(ctx, capabilitiesID)
-		if err != nil {
-			i.logger.Error(err, "Error getting capability", "capabilitiesID", capabilitiesID)
-			continue
-		}
-
-		err = i.k8sClient.UpdateKDLUserToolsCR(ctx, resourceName, data, &crd)
+		err = i.k8sClient.UpdateKDLUserToolsCR(ctx, resourceName, &crd)
 		if err != nil {
 			i.logger.Error(err, "Error updating KDL UserTools CR in k8s", "userToolName", resourceName)
 		}

--- a/app/api/usecase/user/interactor.go
+++ b/app/api/usecase/user/interactor.go
@@ -225,7 +225,10 @@ func (i *Interactor) StartTools(ctx context.Context, email string, runtimeID, ca
 
 	i.logger.Info("Creating user tools for user", "email", email)
 
-	err = i.k8sClient.CreateKDLUserToolsCR(ctx, user.Username, data)
+	data.Username = user.Username
+	data.SlugUsername = user.UsernameSlug()
+
+	err = i.k8sClient.CreateKDLUserToolsCR(ctx, data)
 	if err != nil {
 		return entity.User{}, err
 	}

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -842,7 +842,6 @@ func TestInteractor_UpdateKDLUserTools(t *testing.T) {
 	configMap.Data["template"] = ""
 
 	crd := map[string]interface{}{}
-	data := k8s.UserToolsData{}
 
 	listKDLUserTools := []unstructured.Unstructured{
 		{
@@ -862,10 +861,8 @@ func TestInteractor_UpdateKDLUserTools(t *testing.T) {
 
 	s.mocks.k8sClientMock.EXPECT().GetConfigMapTemplateNameKDLUserTools().Return(templateConfigMap)
 	s.mocks.k8sClientMock.EXPECT().GetConfigMap(ctx, templateConfigMap).Return(&configMap, nil)
-	s.mocks.runtimeRepo.EXPECT().Get(ctx, "12345").Return(entity.Runtime{}, nil)
-	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, "54321").Return(entity.Capabilities{}, nil)
 	s.mocks.k8sClientMock.EXPECT().ListKDLUserToolsCR(ctx).Return(listKDLUserTools, nil)
-	s.mocks.k8sClientMock.EXPECT().UpdateKDLUserToolsCR(ctx, "kdlusertools-v1", data, &crd).Return(nil)
+	s.mocks.k8sClientMock.EXPECT().UpdateKDLUserToolsCR(ctx, "kdlusertools-v1", &crd).Return(nil)
 
 	err := s.interactor.UpdateKDLUserTools(ctx)
 	require.NoError(t, err)
@@ -883,7 +880,6 @@ func TestInteractor_UpdateKDLUserTools_UpdateKDLUserToolsCR_Error(t *testing.T) 
 	configMap.Data["template"] = ""
 
 	crd := map[string]interface{}{}
-	data := k8s.UserToolsData{}
 
 	listKDLUserTools := []unstructured.Unstructured{
 		{
@@ -904,141 +900,7 @@ func TestInteractor_UpdateKDLUserTools_UpdateKDLUserToolsCR_Error(t *testing.T) 
 	s.mocks.k8sClientMock.EXPECT().GetConfigMapTemplateNameKDLUserTools().Return(templateConfigMap)
 	s.mocks.k8sClientMock.EXPECT().GetConfigMap(ctx, templateConfigMap).Return(&configMap, nil)
 	s.mocks.k8sClientMock.EXPECT().ListKDLUserToolsCR(ctx).Return(listKDLUserTools, nil)
-	s.mocks.runtimeRepo.EXPECT().Get(ctx, "12345").Return(entity.Runtime{}, nil)
-	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, "54321").Return(entity.Capabilities{}, nil)
-	s.mocks.k8sClientMock.EXPECT().UpdateKDLUserToolsCR(ctx, "kdlusertools-v1", data, &crd).Return(errUpdatingCrd)
-
-	// even if there is an error updating the CRD,
-	// the function should return no error to allow updating the next CRD
-	err := s.interactor.UpdateKDLUserTools(ctx)
-	require.NoError(t, err)
-}
-func TestInteractor_UpdateKDLUserTools_NoSpec(t *testing.T) {
-	s := newUserSuite(t)
-	defer s.ctrl.Finish()
-
-	ctx := context.Background()
-
-	configMap := v1.ConfigMap{
-		Data: map[string]string{},
-	}
-	configMap.Data["template"] = ""
-
-	listKDLUserTools := []unstructured.Unstructured{
-		{
-			Object: map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"name": "kdlusertools-v1",
-				},
-			},
-		},
-	}
-
-	s.mocks.k8sClientMock.EXPECT().GetConfigMapTemplateNameKDLUserTools().Return(templateConfigMap)
-	s.mocks.k8sClientMock.EXPECT().GetConfigMap(ctx, templateConfigMap).Return(&configMap, nil)
-	s.mocks.k8sClientMock.EXPECT().ListKDLUserToolsCR(ctx).Return(listKDLUserTools, nil)
-
-	// even if there is an error updating the CRD,
-	// the function should return no error to allow updating the next CRD
-	err := s.interactor.UpdateKDLUserTools(ctx)
-	require.NoError(t, err)
-}
-
-func TestInteractor_UpdateKDLUserTools_NoPodLabels(t *testing.T) {
-	s := newUserSuite(t)
-	defer s.ctrl.Finish()
-
-	ctx := context.Background()
-
-	configMap := v1.ConfigMap{
-		Data: map[string]string{},
-	}
-	configMap.Data["template"] = ""
-
-	listKDLUserTools := []unstructured.Unstructured{
-		{
-			Object: map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"name": "kdlusertools-v1",
-				},
-				"spec": map[string]interface{}{},
-			},
-		},
-	}
-
-	s.mocks.k8sClientMock.EXPECT().GetConfigMapTemplateNameKDLUserTools().Return(templateConfigMap)
-	s.mocks.k8sClientMock.EXPECT().GetConfigMap(ctx, templateConfigMap).Return(&configMap, nil)
-	s.mocks.k8sClientMock.EXPECT().ListKDLUserToolsCR(ctx).Return(listKDLUserTools, nil)
-
-	// even if there is an error updating the CRD,
-	// the function should return no error to allow updating the next CRD
-	err := s.interactor.UpdateKDLUserTools(ctx)
-	require.NoError(t, err)
-}
-
-func TestInteractor_UpdateKDLUserTools_NoRuntimeId(t *testing.T) {
-	s := newUserSuite(t)
-	defer s.ctrl.Finish()
-
-	ctx := context.Background()
-
-	configMap := v1.ConfigMap{
-		Data: map[string]string{},
-	}
-	configMap.Data["template"] = ""
-
-	listKDLUserTools := []unstructured.Unstructured{
-		{
-			Object: map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"name": "kdlusertools-v1",
-				},
-				"spec": map[string]interface{}{
-					"podLabels": map[string]interface{}{},
-				},
-			},
-		},
-	}
-
-	s.mocks.k8sClientMock.EXPECT().GetConfigMapTemplateNameKDLUserTools().Return(templateConfigMap)
-	s.mocks.k8sClientMock.EXPECT().GetConfigMap(ctx, templateConfigMap).Return(&configMap, nil)
-	s.mocks.k8sClientMock.EXPECT().ListKDLUserToolsCR(ctx).Return(listKDLUserTools, nil)
-
-	// even if there is an error updating the CRD,
-	// the function should return no error to allow updating the next CRD
-	err := s.interactor.UpdateKDLUserTools(ctx)
-	require.NoError(t, err)
-}
-
-func TestInteractor_UpdateKDLUserTools_NoCapabilityId(t *testing.T) {
-	s := newUserSuite(t)
-	defer s.ctrl.Finish()
-
-	ctx := context.Background()
-
-	configMap := v1.ConfigMap{
-		Data: map[string]string{},
-	}
-	configMap.Data["template"] = ""
-
-	listKDLUserTools := []unstructured.Unstructured{
-		{
-			Object: map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"name": "kdlusertools-v1",
-				},
-				"spec": map[string]interface{}{
-					"podLabels": map[string]interface{}{
-						"runtimeId": "12345",
-					},
-				},
-			},
-		},
-	}
-
-	s.mocks.k8sClientMock.EXPECT().GetConfigMapTemplateNameKDLUserTools().Return(templateConfigMap)
-	s.mocks.k8sClientMock.EXPECT().GetConfigMap(ctx, templateConfigMap).Return(&configMap, nil)
-	s.mocks.k8sClientMock.EXPECT().ListKDLUserToolsCR(ctx).Return(listKDLUserTools, nil)
+	s.mocks.k8sClientMock.EXPECT().UpdateKDLUserToolsCR(ctx, "kdlusertools-v1", &crd).Return(errUpdatingCrd)
 
 	// even if there is an error updating the CRD,
 	// the function should return no error to allow updating the next CRD

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -291,6 +291,7 @@ func TestInteractor_StartTools(t *testing.T) {
 
 	const (
 		username     = "john"
+		slugUsername = "john"
 		email        = "john@doe.com"
 		toolsRunning = false
 		runtimeImage = "konstellation/image"
@@ -310,6 +311,8 @@ func TestInteractor_StartTools(t *testing.T) {
 	runtimeID := "12345"
 
 	data := k8s.UserToolsData{
+		Username:     username,
+		SlugUsername: slugUsername,
 		RuntimeID:    runtimeID,
 		RuntimeImage: runtimeImage,
 		RuntimeTag:   runtimeTag,
@@ -324,7 +327,7 @@ func TestInteractor_StartTools(t *testing.T) {
 	s.mocks.runtimeRepo.EXPECT().Get(ctx, runtimeID).Return(expectedRuntime, nil)
 	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, capability.ID).Return(capability, nil)
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).Return(toolsRunning, nil)
-	s.mocks.k8sClientMock.EXPECT().CreateKDLUserToolsCR(ctx, username, data).Return(nil)
+	s.mocks.k8sClientMock.EXPECT().CreateKDLUserToolsCR(ctx, data).Return(nil)
 
 	returnedUser, err := s.interactor.StartTools(ctx, email, &runtimeID, &capability.ID)
 
@@ -339,6 +342,7 @@ func TestInteractor_StartTools_DefaultRuntime(t *testing.T) {
 
 	const (
 		username     = "john"
+		slugUsername = "john"
 		email        = "john@doe.com"
 		toolsRunning = false
 	)
@@ -354,6 +358,8 @@ func TestInteractor_StartTools_DefaultRuntime(t *testing.T) {
 	}
 
 	data := k8s.UserToolsData{
+		Username:     username,
+		SlugUsername: slugUsername,
 		Capabilities: capability,
 	}
 
@@ -367,7 +373,7 @@ func TestInteractor_StartTools_DefaultRuntime(t *testing.T) {
 
 	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, capability.ID).Return(capability, nil)
 	// AND the CR creation does not return any error
-	s.mocks.k8sClientMock.EXPECT().CreateKDLUserToolsCR(ctx, username, data).Return(nil)
+	s.mocks.k8sClientMock.EXPECT().CreateKDLUserToolsCR(ctx, data).Return(nil)
 
 	// WHEN the tools are started
 	returnedUser, err := s.interactor.StartTools(ctx, email, nil, &capability.ID)
@@ -390,6 +396,7 @@ func TestInteractor_StartTools_Replace(t *testing.T) {
 
 	const (
 		username     = "john"
+		slugUsername = "john"
 		email        = "john@doe.com"
 		toolsRunning = true
 		dockerImage  = "image"
@@ -411,6 +418,8 @@ func TestInteractor_StartTools_Replace(t *testing.T) {
 	}
 
 	data := k8s.UserToolsData{
+		Username:     username,
+		SlugUsername: slugUsername,
 		RuntimeID:    runtimeID,
 		RuntimeImage: dockerImage,
 		RuntimeTag:   dockerTag,
@@ -430,7 +439,7 @@ func TestInteractor_StartTools_Replace(t *testing.T) {
 
 	s.mocks.capabilitiesRepo.EXPECT().Get(ctx, capability.ID).Return(capability, nil)
 	// AND the CR creation does not return any error
-	s.mocks.k8sClientMock.EXPECT().CreateKDLUserToolsCR(ctx, username, data).Return(nil)
+	s.mocks.k8sClientMock.EXPECT().CreateKDLUserToolsCR(ctx, data).Return(nil)
 
 	// WHEN the tools are started
 	returnedUser, err := s.interactor.StartTools(ctx, email, &runtimeID, &capability.ID)


### PR DESCRIPTION
## Motivation and Context

This simplifies the logic of the ConfigMap Watcher functionality that updates CR when the CR templates in ConfigMaps change. The previously applied input fields are now stored within the CRs itself and are re-applied upon update.

This allows for the propagation of MinIO credentials upon update.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [X] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

MinIO credentials are lost when CR template updates.

Closes #

## What is the new behavior?

MinIO credentials are propagated when CR template updates.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

Now, CRD and CR require extra field `specs.inputData`

## Other information
