### PR TITLE
fix(API): [KDL6-290] fixing minio project creation

### DIFF
--- a/app/api/usecase/project/interactor.go
+++ b/app/api/usecase/project/interactor.go
@@ -176,6 +176,12 @@ func (i *interactor) Create(ctx context.Context, opt CreateProjectOption) (entit
 		return entity.Project{}, err
 	}
 
+	// Create Minio policy for the project user
+	err = i.minioAdminService.CreateProjectPolicy(ctx, opt.ProjectID)
+	if err != nil {
+		return entity.Project{}, err
+	}
+
 	// Create Minio project user
 	accessKey, err := i.minioAdminService.CreateProjectUser(ctx, opt.ProjectID, secretKey)
 	if err != nil {
@@ -185,12 +191,6 @@ func (i *interactor) Create(ctx context.Context, opt CreateProjectOption) (entit
 	project.MinioAccessKey = entity.MinioAccessKey{
 		AccessKey: accessKey,
 		SecretKey: secretKey,
-	}
-
-	// Create Minio policy for the project user
-	err = i.minioAdminService.CreateProjectPolicy(ctx, opt.ProjectID)
-	if err != nil {
-		return entity.Project{}, err
 	}
 
 	// Create a k8s KDLProject containing a MLFLow instance


### PR DESCRIPTION
## Motivation and Context

It has been found (by @Javier Gil ) that the order of MinIO Project Policy creation and MinIO Project User creation is reversed. 

## PR Checklist

- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [ ] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

infrastructure/minio-admin tests correct behavior creating policy before user
usecase/project applies the inverse order.

## What is the new behavior?
usecase/project to follow the same order: creating policy before user

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information
