### PR TITLE
fix(API): [KDL6-305] Update project creator's MinIO policy

### DIFF
--- a/app/api/usecase/project/interactor.go
+++ b/app/api/usecase/project/interactor.go
@@ -203,6 +203,12 @@ func (i *interactor) Create(ctx context.Context, opt CreateProjectOption) (entit
 		SecretKey: secretKey,
 	}
 
+	// Add admin as member of the project on MinIO
+	err = i.minioAdminService.JoinProject(ctx, opt.Owner.Email, opt.ProjectID)
+	if err != nil {
+		return entity.Project{}, fmt.Errorf("%w: user ID=%s", err, opt.Owner.ID)
+	}
+
 	// Create a k8s KDLProject containing a MLFLow instance
 	err = i.k8sClient.CreateKDLProjectCR(ctx, k8s.ProjectData{ProjectID: opt.ProjectID, MinioAccessKey: project.MinioAccessKey})
 	if err != nil {

--- a/app/api/usecase/project/interactor_test.go
+++ b/app/api/usecase/project/interactor_test.go
@@ -96,6 +96,7 @@ func TestInteractor_Create(t *testing.T) {
 		projectMinioSecretKey = "projectY123"
 		ownerUserID           = "user.1234"
 		ownerUsername         = "john"
+		ownerEmail            = "john@doe.com"
 	)
 
 	url := "https://github.com/org/repo.git"
@@ -165,6 +166,7 @@ func TestInteractor_Create(t *testing.T) {
 	s.mocks.randomGenerator.EXPECT().GenerateRandomString(40).Return(projectMinioSecretKey, nil)
 	s.mocks.minioAdminService.EXPECT().CreateProjectUser(ctx, testProjectID, projectMinioSecretKey).Return(testProjectID, nil)
 	s.mocks.minioAdminService.EXPECT().CreateProjectPolicy(ctx, testProjectID).Return(nil)
+	s.mocks.minioAdminService.EXPECT().JoinProject(ctx, ownerEmail, testProjectID).Return(nil)
 
 	createdProject, err := s.interactor.Create(ctx, project.CreateProjectOption{
 		ProjectID:   testProjectID,
@@ -172,7 +174,7 @@ func TestInteractor_Create(t *testing.T) {
 		Description: projectDesc,
 		URL:         &url,
 		Username:    &username,
-		Owner:       entity.User{ID: ownerUserID, Username: ownerUsername},
+		Owner:       entity.User{ID: ownerUserID, Username: ownerUsername, Email: ownerEmail},
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation and Context

The project creator needs to be added as a project member on MinIO.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [X] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Project creator has no access to project bucket.

## What is the new behavior?

Project creator joins the project on MinIO and thus has access to the project bucket.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
