### PR TITLE
feat(api): [KDL6-285] sync user data

### DIFF
--- a/app/api/http/main.go
+++ b/app/api/http/main.go
@@ -174,11 +174,6 @@ func actionsBeforeStartingHTTPServer(logger logr.Logger, repos dbRepos, interact
 		logger.Error(err, "Error creating indexes for users")
 	}
 
-	// Create service accounts for users
-	if err = interactors.userInteractor.SynchronizeServiceAccountsForUsers(); err != nil {
-		logger.Error(err, "Unexpected error creating serviceAccount for users")
-	}
-
 	// Start watching ConfigMaps
 	go func() {
 		err := interactors.configmapInteractor.WatchConfigMapTemplates(context.Background())

--- a/app/api/infrastructure/graph/generated/generated.go
+++ b/app/api/infrastructure/graph/generated/generated.go
@@ -77,17 +77,18 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddAPIToken        func(childComplexity int, input *model.APITokenInput) int
-		AddMembers         func(childComplexity int, input model.AddMembersInput) int
-		CreateProject      func(childComplexity int, input model.CreateProjectInput) int
-		DeleteProject      func(childComplexity int, input model.DeleteProjectInput) int
-		RegenerateSSHKey   func(childComplexity int) int
-		RemoveAPIToken     func(childComplexity int, input *model.RemoveAPITokenInput) int
-		RemoveMembers      func(childComplexity int, input model.RemoveMembersInput) int
-		SetActiveUserTools func(childComplexity int, input model.SetActiveUserToolsInput) int
-		UpdateAccessLevel  func(childComplexity int, input model.UpdateAccessLevelInput) int
-		UpdateMembers      func(childComplexity int, input model.UpdateMembersInput) int
-		UpdateProject      func(childComplexity int, input model.UpdateProjectInput) int
+		AddAPIToken          func(childComplexity int, input *model.APITokenInput) int
+		AddMembers           func(childComplexity int, input model.AddMembersInput) int
+		CreateProject        func(childComplexity int, input model.CreateProjectInput) int
+		DeleteProject        func(childComplexity int, input model.DeleteProjectInput) int
+		RegenerateSSHKey     func(childComplexity int) int
+		RemoveAPIToken       func(childComplexity int, input *model.RemoveAPITokenInput) int
+		RemoveMembers        func(childComplexity int, input model.RemoveMembersInput) int
+		SetActiveUserTools   func(childComplexity int, input model.SetActiveUserToolsInput) int
+		SynchronizeUsersData func(childComplexity int, input *model.SyncUsersDataInput) int
+		UpdateAccessLevel    func(childComplexity int, input model.UpdateAccessLevelInput) int
+		UpdateMembers        func(childComplexity int, input model.UpdateMembersInput) int
+		UpdateProject        func(childComplexity int, input model.UpdateProjectInput) int
 	}
 
 	Project struct {
@@ -181,6 +182,7 @@ type MutationResolver interface {
 	UpdateProject(ctx context.Context, input model.UpdateProjectInput) (*entity.Project, error)
 	AddAPIToken(ctx context.Context, input *model.APITokenInput) (*entity.APIToken, error)
 	RemoveAPIToken(ctx context.Context, input *model.RemoveAPITokenInput) (*entity.APIToken, error)
+	SynchronizeUsersData(ctx context.Context, input *model.SyncUsersDataInput) (*bool, error)
 }
 type ProjectResolver interface {
 	CreationDate(ctx context.Context, obj *entity.Project) (string, error)
@@ -412,6 +414,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.SetActiveUserTools(childComplexity, args["input"].(model.SetActiveUserToolsInput)), true
+
+	case "Mutation.synchronizeUsersData":
+		if e.complexity.Mutation.SynchronizeUsersData == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_synchronizeUsersData_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.SynchronizeUsersData(childComplexity, args["input"].(*model.SyncUsersDataInput)), true
 
 	case "Mutation.updateAccessLevel":
 		if e.complexity.Mutation.UpdateAccessLevel == nil {
@@ -818,6 +832,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRemoveMembersInput,
 		ec.unmarshalInputRepositoryInput,
 		ec.unmarshalInputSetActiveUserToolsInput,
+		ec.unmarshalInputSyncUsersDataInput,
 		ec.unmarshalInputUpdateAccessLevelInput,
 		ec.unmarshalInputUpdateMembersInput,
 		ec.unmarshalInputUpdateProjectInput,
@@ -952,6 +967,8 @@ type Mutation {
 
   addApiToken(input: ApiTokenInput): ApiToken
   removeApiToken(input: RemoveApiTokenInput): ApiToken!
+
+  synchronizeUsersData(input: SyncUsersDataInput): Boolean
 }
 
 type Capability {
@@ -1102,6 +1119,13 @@ input ApiTokenInput {
 
 input RemoveApiTokenInput {
   apiTokenId: ID!
+}
+
+input SyncUsersDataInput{
+  serviceAccount: Boolean!
+  sshKeys: Boolean!
+  minioUser: Boolean!
+  userIds: [ID!]!
 }
 `, BuiltIn: false},
 }
@@ -1304,6 +1328,34 @@ func (ec *executionContext) field_Mutation_setActiveUserTools_argsInput(
 	}
 
 	var zeroVal model.SetActiveUserToolsInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_synchronizeUsersData_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_synchronizeUsersData_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_synchronizeUsersData_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*model.SyncUsersDataInput, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal *model.SyncUsersDataInput
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalOSyncUsersDataInput2ᚖgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐSyncUsersDataInput(ctx, tmp)
+	}
+
+	var zeroVal *model.SyncUsersDataInput
 	return zeroVal, nil
 }
 
@@ -3021,6 +3073,58 @@ func (ec *executionContext) fieldContext_Mutation_removeApiToken(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_removeApiToken_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_synchronizeUsersData(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_synchronizeUsersData(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().SynchronizeUsersData(rctx, fc.Args["input"].(*model.SyncUsersDataInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_synchronizeUsersData(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_synchronizeUsersData_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -7740,6 +7844,54 @@ func (ec *executionContext) unmarshalInputSetActiveUserToolsInput(ctx context.Co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputSyncUsersDataInput(ctx context.Context, obj any) (model.SyncUsersDataInput, error) {
+	var it model.SyncUsersDataInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"serviceAccount", "sshKeys", "minioUser", "userIds"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "serviceAccount":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceAccount"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServiceAccount = data
+		case "sshKeys":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sshKeys"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SSHKeys = data
+		case "minioUser":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("minioUser"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MinioUser = data
+		case "userIds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userIds"))
+			data, err := ec.unmarshalNID2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UserIds = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateAccessLevelInput(ctx context.Context, obj any) (model.UpdateAccessLevelInput, error) {
 	var it model.UpdateAccessLevelInput
 	asMap := map[string]any{}
@@ -8224,6 +8376,10 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "synchronizeUsersData":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_synchronizeUsersData(ctx, field)
+			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10395,6 +10551,14 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	}
 	res := graphql.MarshalString(*v)
 	return res
+}
+
+func (ec *executionContext) unmarshalOSyncUsersDataInput2ᚖgithubᚗcomᚋkonstellationᚑioᚋkdlᚑserverᚋappᚋapiᚋinfrastructureᚋgraphᚋmodelᚐSyncUsersDataInput(ctx context.Context, v any) (*model.SyncUsersDataInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputSyncUsersDataInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/app/api/infrastructure/graph/model/models_gen.go
+++ b/app/api/infrastructure/graph/model/models_gen.go
@@ -63,6 +63,13 @@ type SetActiveUserToolsInput struct {
 	CapabilitiesID *string `json:"capabilitiesId,omitempty"`
 }
 
+type SyncUsersDataInput struct {
+	ServiceAccount bool     `json:"serviceAccount"`
+	SSHKeys        bool     `json:"sshKeys"`
+	MinioUser      bool     `json:"minioUser"`
+	UserIds        []string `json:"userIds"`
+}
+
 type UpdateAccessLevelInput struct {
 	UserIds     []string           `json:"userIds"`
 	AccessLevel entity.AccessLevel `json:"accessLevel"`

--- a/app/api/infrastructure/graph/schema.resolvers.go
+++ b/app/api/infrastructure/graph/schema.resolvers.go
@@ -198,6 +198,23 @@ func (r *mutationResolver) RemoveAPIToken(ctx context.Context, input *model.Remo
 	return nil, entity.ErrNotImplemented
 }
 
+// SynchronizeUsersData is the resolver for the synchronizeUsersData field.
+func (r *mutationResolver) SynchronizeUsersData(ctx context.Context, input *model.SyncUsersDataInput) (*bool, error) {
+	lastError := error(nil)
+	for _, userID := range input.UserIds {
+		err := r.users.SyncUserData(ctx, userID, input.ServiceAccount, input.SSHKeys, input.MinioUser)
+		if err != nil {
+			lastError = err
+			r.logger.Error(err, "Error synchronizing user data", "userID", userID)
+		}
+	}
+	if lastError != nil {
+		return nil, lastError
+	}
+	result := true
+	return &result, nil
+}
+
 // CreationDate is the resolver for the creationDate field.
 func (r *projectResolver) CreationDate(ctx context.Context, obj *entity.Project) (string, error) {
 	return obj.CreationDate.Format(time.RFC3339), nil

--- a/app/api/infrastructure/minioadminservice/mocks_interface.go
+++ b/app/api/infrastructure/minioadminservice/mocks_interface.go
@@ -64,18 +64,18 @@ func (mr *MockMinioAdminInterfaceMockRecorder) CreateProjectUser(ctx, projectNam
 }
 
 // CreateUser mocks base method.
-func (m *MockMinioAdminInterface) CreateUser(ctx context.Context, userSlug, secretKey string) (string, error) {
+func (m *MockMinioAdminInterface) CreateUser(ctx context.Context, email, secretKey string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUser", ctx, userSlug, secretKey)
+	ret := m.ctrl.Call(m, "CreateUser", ctx, email, secretKey)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUser indicates an expected call of CreateUser.
-func (mr *MockMinioAdminInterfaceMockRecorder) CreateUser(ctx, userSlug, secretKey interface{}) *gomock.Call {
+func (mr *MockMinioAdminInterfaceMockRecorder) CreateUser(ctx, email, secretKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockMinioAdminInterface)(nil).CreateUser), ctx, userSlug, secretKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockMinioAdminInterface)(nil).CreateUser), ctx, email, secretKey)
 }
 
 // DeleteProjectPolicy mocks base method.
@@ -107,43 +107,43 @@ func (mr *MockMinioAdminInterfaceMockRecorder) DeleteProjectUser(ctx, projectNam
 }
 
 // DeleteUser mocks base method.
-func (m *MockMinioAdminInterface) DeleteUser(ctx context.Context, userSlug string) error {
+func (m *MockMinioAdminInterface) DeleteUser(ctx context.Context, email string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteUser", ctx, userSlug)
+	ret := m.ctrl.Call(m, "DeleteUser", ctx, email)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteUser indicates an expected call of DeleteUser.
-func (mr *MockMinioAdminInterfaceMockRecorder) DeleteUser(ctx, userSlug interface{}) *gomock.Call {
+func (mr *MockMinioAdminInterfaceMockRecorder) DeleteUser(ctx, email interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockMinioAdminInterface)(nil).DeleteUser), ctx, userSlug)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockMinioAdminInterface)(nil).DeleteUser), ctx, email)
 }
 
 // JoinProject mocks base method.
-func (m *MockMinioAdminInterface) JoinProject(ctx context.Context, userSlug, projectName string) error {
+func (m *MockMinioAdminInterface) JoinProject(ctx context.Context, email, projectName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JoinProject", ctx, userSlug, projectName)
+	ret := m.ctrl.Call(m, "JoinProject", ctx, email, projectName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JoinProject indicates an expected call of JoinProject.
-func (mr *MockMinioAdminInterfaceMockRecorder) JoinProject(ctx, userSlug, projectName interface{}) *gomock.Call {
+func (mr *MockMinioAdminInterfaceMockRecorder) JoinProject(ctx, email, projectName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinProject", reflect.TypeOf((*MockMinioAdminInterface)(nil).JoinProject), ctx, userSlug, projectName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinProject", reflect.TypeOf((*MockMinioAdminInterface)(nil).JoinProject), ctx, email, projectName)
 }
 
 // LeaveProject mocks base method.
-func (m *MockMinioAdminInterface) LeaveProject(ctx context.Context, userSlug, projectName string) error {
+func (m *MockMinioAdminInterface) LeaveProject(ctx context.Context, email, projectName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LeaveProject", ctx, userSlug, projectName)
+	ret := m.ctrl.Call(m, "LeaveProject", ctx, email, projectName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LeaveProject indicates an expected call of LeaveProject.
-func (mr *MockMinioAdminInterfaceMockRecorder) LeaveProject(ctx, userSlug, projectName interface{}) *gomock.Call {
+func (mr *MockMinioAdminInterfaceMockRecorder) LeaveProject(ctx, email, projectName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveProject", reflect.TypeOf((*MockMinioAdminInterface)(nil).LeaveProject), ctx, userSlug, projectName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveProject", reflect.TypeOf((*MockMinioAdminInterface)(nil).LeaveProject), ctx, email, projectName)
 }

--- a/app/api/usecase/user/interactor_test.go
+++ b/app/api/usecase/user/interactor_test.go
@@ -926,8 +926,8 @@ func TestInteractor_SyncUserData(t *testing.T) {
 	s.mocks.k8sClientMock.EXPECT().GetUserSSHKeyPublic(ctx, usernameSlug).Return([]byte{}, nil)
 	s.mocks.k8sClientMock.EXPECT().UpdateUserSSHKeySecret(ctx, user, gomock.Any(), gomock.Any()).Return(nil)
 	s.mocks.repo.EXPECT().UpdateSSHKey(ctx, username, gomock.Any()).Return(nil)
-	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil)
-	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, "").Return(email, nil)
+	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil).AnyTimes()
+	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, user.MinioAccessKey.SecretKey).Return(email, nil)
 
 	err := s.interactor.SyncUserData(ctx, id, syncSA, syncSSHKeys, syncMinio)
 	require.NoError(t, err)
@@ -952,6 +952,10 @@ func TestInteractor_SyncUserData_InputSyncIsFalse(t *testing.T) {
 		ID:       id,
 		Username: username,
 		Email:    email,
+		MinioAccessKey: entity.MinioAccessKey{
+			AccessKey: email,
+			SecretKey: "john-doe-secret",
+		},
 	}
 
 	s.mocks.repo.EXPECT().Get(ctx, id).Return(user, nil)
@@ -999,6 +1003,10 @@ func TestInteractor_SyncUserData_CreateServiceAccountError(t *testing.T) {
 		ID:       id,
 		Username: username,
 		Email:    email,
+		MinioAccessKey: entity.MinioAccessKey{
+			AccessKey: email,
+			SecretKey: "john-doe-secret",
+		},
 	}
 
 	s.mocks.repo.EXPECT().Get(ctx, id).Return(user, nil)
@@ -1008,8 +1016,8 @@ func TestInteractor_SyncUserData_CreateServiceAccountError(t *testing.T) {
 	s.mocks.k8sClientMock.EXPECT().GetUserSSHKeyPublic(ctx, usernameSlug).Return([]byte{}, nil)
 	s.mocks.k8sClientMock.EXPECT().UpdateUserSSHKeySecret(ctx, user, gomock.Any(), gomock.Any()).Return(nil)
 	s.mocks.repo.EXPECT().UpdateSSHKey(ctx, username, gomock.Any()).Return(nil)
-	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil)
-	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, "").Return(email, nil)
+	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil).AnyTimes()
+	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, user.MinioAccessKey.SecretKey).Return(email, nil)
 
 	err := s.interactor.SyncUserData(ctx, id, syncSA, syncSSHKeys, syncMinio)
 	require.Error(t, err)
@@ -1035,6 +1043,10 @@ func TestInteractor_SyncUserData_RegenerateSSHKeysError(t *testing.T) {
 		ID:       id,
 		Username: username,
 		Email:    email,
+		MinioAccessKey: entity.MinioAccessKey{
+			AccessKey: email,
+			SecretKey: "john-doe-secret",
+		},
 	}
 
 	s.mocks.repo.EXPECT().Get(ctx, id).Return(user, nil)
@@ -1042,8 +1054,8 @@ func TestInteractor_SyncUserData_RegenerateSSHKeysError(t *testing.T) {
 	s.mocks.k8sClientMock.EXPECT().IsUserToolPODRunning(ctx, username).Return(false, nil)
 	s.mocks.sshGenerator.EXPECT().NewKeys().Return(entity.SSHKey{}, nil)
 	s.mocks.k8sClientMock.EXPECT().GetUserSSHKeyPublic(ctx, usernameSlug).Return(nil, errUnexpected)
-	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil)
-	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, "").Return(email, nil)
+	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil).AnyTimes()
+	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, user.MinioAccessKey.SecretKey).Return(email, nil)
 
 	err := s.interactor.SyncUserData(ctx, id, syncSA, syncSSHKeys, syncMinio)
 	require.Error(t, err)
@@ -1069,6 +1081,10 @@ func TestInteractor_SyncUserData_CreateMinioUserError(t *testing.T) {
 		ID:       id,
 		Username: username,
 		Email:    email,
+		MinioAccessKey: entity.MinioAccessKey{
+			AccessKey: email,
+			SecretKey: "john-doe-secret",
+		},
 	}
 
 	s.mocks.repo.EXPECT().Get(ctx, id).Return(user, nil)
@@ -1078,8 +1094,8 @@ func TestInteractor_SyncUserData_CreateMinioUserError(t *testing.T) {
 	s.mocks.k8sClientMock.EXPECT().GetUserSSHKeyPublic(ctx, usernameSlug).Return([]byte{}, nil)
 	s.mocks.k8sClientMock.EXPECT().UpdateUserSSHKeySecret(ctx, user, gomock.Any(), gomock.Any()).Return(nil)
 	s.mocks.repo.EXPECT().UpdateSSHKey(ctx, username, gomock.Any()).Return(nil)
-	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil)
-	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, "").Return("", errUnexpected)
+	s.mocks.repo.EXPECT().GetByUsername(ctx, username).Return(user, nil).AnyTimes()
+	s.mocks.minioAdminService.EXPECT().CreateUser(ctx, email, user.MinioAccessKey.SecretKey).Return("", errUnexpected)
 
 	err := s.interactor.SyncUserData(ctx, id, syncSA, syncSSHKeys, syncMinio)
 	require.Error(t, err)

--- a/app/api/usecase/user/interface.go
+++ b/app/api/usecase/user/interface.go
@@ -45,6 +45,6 @@ type UseCase interface {
 	GetByID(ctx context.Context, userID string) (entity.User, error)
 	RegenerateSSHKeys(ctx context.Context, user entity.User) (entity.User, error)
 	GetKubeconfig(ctx context.Context, username string) (string, error)
-	SynchronizeServiceAccountsForUsers() error
+	SyncUserData(ctx context.Context, userID string, syncSA, syncSSHKeys, syncMinio bool) error
 	UpdateKDLUserTools(ctx context.Context) error
 }

--- a/app/api/usecase/user/mocks_interface.go
+++ b/app/api/usecase/user/mocks_interface.go
@@ -454,18 +454,18 @@ func (mr *MockUseCaseMockRecorder) StopTools(ctx, email interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTools", reflect.TypeOf((*MockUseCase)(nil).StopTools), ctx, email)
 }
 
-// SynchronizeServiceAccountsForUsers mocks base method.
-func (m *MockUseCase) SynchronizeServiceAccountsForUsers() error {
+// SyncUserData mocks base method.
+func (m *MockUseCase) SyncUserData(ctx context.Context, userID string, syncSA, syncSSHKeys, syncMinio bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SynchronizeServiceAccountsForUsers")
+	ret := m.ctrl.Call(m, "SyncUserData", ctx, userID, syncSA, syncSSHKeys, syncMinio)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SynchronizeServiceAccountsForUsers indicates an expected call of SynchronizeServiceAccountsForUsers.
-func (mr *MockUseCaseMockRecorder) SynchronizeServiceAccountsForUsers() *gomock.Call {
+// SyncUserData indicates an expected call of SyncUserData.
+func (mr *MockUseCaseMockRecorder) SyncUserData(ctx, userID, syncSA, syncSSHKeys, syncMinio interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchronizeServiceAccountsForUsers", reflect.TypeOf((*MockUseCase)(nil).SynchronizeServiceAccountsForUsers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncUserData", reflect.TypeOf((*MockUseCase)(nil).SyncUserData), ctx, userID, syncSA, syncSSHKeys, syncMinio)
 }
 
 // UpdateAccessLevel mocks base method.

--- a/app/graphql/schema.graphqls
+++ b/app/graphql/schema.graphqls
@@ -32,6 +32,8 @@ type Mutation {
 
   addApiToken(input: ApiTokenInput): ApiToken
   removeApiToken(input: RemoveApiTokenInput): ApiToken!
+
+  synchronizeUsersData(input: SyncUsersDataInput): Boolean
 }
 
 type Capability {
@@ -182,4 +184,11 @@ input ApiTokenInput {
 
 input RemoveApiTokenInput {
   apiTokenId: ID!
+}
+
+input SyncUsersDataInput{
+  serviceAccount: Boolean!
+  sshKeys: Boolean!
+  minioUser: Boolean!
+  userIds: [ID!]!
 }

--- a/app/ui/src/Graphql/mutations/syncronizeUsersData.ts
+++ b/app/ui/src/Graphql/mutations/syncronizeUsersData.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation SynchronizeUsersData($input: SyncUsersDataInput!) {
+    synchronizeUsersData(input: $input)
+  }
+`;

--- a/app/ui/src/Graphql/mutations/types/SynchronizeUsersData.ts
+++ b/app/ui/src/Graphql/mutations/types/SynchronizeUsersData.ts
@@ -1,0 +1,18 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { SyncUsersDataInput } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: SynchronizeUsersData
+// ====================================================
+
+export interface SynchronizeUsersData {
+  synchronizeUsersData: boolean | null;
+}
+
+export interface SynchronizeUsersDataVariables {
+  input: SyncUsersDataInput;
+}

--- a/app/ui/src/Graphql/types/globalTypes.ts
+++ b/app/ui/src/Graphql/types/globalTypes.ts
@@ -60,6 +60,13 @@ export interface SetActiveUserToolsInput {
   capabilitiesId?: string | null;
 }
 
+export interface SyncUsersDataInput {
+  serviceAccount: boolean;
+  sshKeys: boolean;
+  minioUser: boolean;
+  userIds: string[];
+}
+
 export interface UpdateAccessLevelInput {
   userIds: string[];
   accessLevel: AccessLevel;


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Enable new mutation to sync user data with 3pp (k8s and minIO at the moment)
Remove sync user from startup.

## PR Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Please check if your PR fulfills the following requirements:

- [X] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [X] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
