### PR TITLE
feat(app): [KDL6-309] update kubeconfig user menu button

### DIFF
--- a/app/ui/src/Components/SettingsMenu/SettingsMenu.module.scss
+++ b/app/ui/src/Components/SettingsMenu/SettingsMenu.module.scss
@@ -22,6 +22,21 @@
   }
 }
 
+.settingButtonDisabled {
+  background-color: palette(lowlight, 400);
+  border-left: 3px solid transparent;
+  transition:
+    background-color ease 0.3s,
+    border-left-color ease 0.3s,
+    color ease 0.2s, opacity ease 0.3s;
+
+  &:hover {
+    border-left-color: palette(lowlight);
+    color: palette(white);
+    text-shadow: 0 0 16px  palette(white);
+  }
+}
+
 .logoutButton {
   background-color: palette(base, 400);
   border-left: 3px solid transparent;

--- a/app/ui/src/Components/SettingsMenu/SettingsMenu.module.scss
+++ b/app/ui/src/Components/SettingsMenu/SettingsMenu.module.scss
@@ -23,7 +23,7 @@
 }
 
 .settingButtonDisabled {
-  background-color: palette(lowlight, 400);
+  background-color: palette(base, 400);
   border-left: 3px solid transparent;
   transition:
     background-color ease 0.3s,
@@ -31,7 +31,7 @@
     color ease 0.2s, opacity ease 0.3s;
 
   &:hover {
-    border-left-color: palette(lowlight);
+    border-left-color: palette(highlight);
     color: palette(white);
     text-shadow: 0 0 16px  palette(white);
   }

--- a/app/ui/src/Components/SettingsMenu/SettingsMenu.tsx
+++ b/app/ui/src/Components/SettingsMenu/SettingsMenu.tsx
@@ -53,7 +53,17 @@ function SettingsMenu() {
   }
 
   function kubeconfigButton() {
-    if (!data?.me.isKubeconfigEnabled || !runtimeRunning) return <div />;
+    if (!data?.me.isKubeconfigEnabled || !runtimeRunning) {
+      return (
+        <Button
+          label="Kubeconfig"
+          key="Kubeconfig"
+          disabled
+          Icon={DescriptionIcon}
+          className={styles.settingButtonDisabled}
+          align={BUTTON_ALIGN.LEFT}
+        />
+    )};
 
     return (
       <Button

--- a/app/ui/src/Components/SettingsMenu/SettingsMenu.tsx
+++ b/app/ui/src/Components/SettingsMenu/SettingsMenu.tsx
@@ -13,6 +13,7 @@ import { CONFIG } from 'index';
 
 import GetMeQuery from 'Graphql/queries/getMe';
 import { runningRuntime } from 'Graphql/client/cache';
+import Tooltip from 'Components/Tooltip/Tooltip';
 
 const UserSettingsSeparator = ({ label }: CustomOptionProps) => (
   <div className={styles.separator}>{label.toUpperCase()}</div>
@@ -53,17 +54,25 @@ function SettingsMenu() {
   }
 
   function kubeconfigButton() {
+
+    const tooltipProps = {
+      effect: 'solid',
+      textColor: 'white',
+      backgroundColor: '#888',
+    };
     if (!data?.me.isKubeconfigEnabled || !runtimeRunning) {
       return (
-        <Button
-          label="Kubeconfig"
-          key="Kubeconfig"
-          disabled
-          Icon={DescriptionIcon}
-          className={styles.settingButtonDisabled}
-          align={BUTTON_ALIGN.LEFT}
-        />
-    )};
+        <Tooltip tooltipId="settings" spanText="Started UserTools is required" tooltipProps={tooltipProps}>
+          <Button
+            label="Kubeconfig"
+            key="Kubeconfig"
+            disabled
+            Icon={DescriptionIcon}
+            className={styles.settingButtonDisabled}
+            align={BUTTON_ALIGN.LEFT}
+          />
+        </Tooltip>
+      )};
 
     return (
       <Button


### PR DESCRIPTION
## Motivation and Context

Show the kubeconfig button even if usertools aren't running. 

## PR Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Please check if your PR fulfills the following requirements:

- [ ] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [ ] I have updated the documentation accordingly.
- [ ] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Closes #

## What is the new behavior?

If the UserTools aren't running a button show with a Tooltip letting know that UserTools are required to access to Kubeconfig config.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
