### PR TITLE
feat(hack): [KDL6-336] configure kdl to use gitlab repository

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,4 +1,44 @@
-# Local Environment
+# Development
+
+## Requirements
+
+In order to start development on this project you will need these tools:
+
+- **[gettext](https://www.gnu.org/software/gettext/)**: OS package to fill templates during deployment
+- **[helm](https://helm.sh/)**: K8s package manager. Make sure you have v3+
+- **[helmfile](https://helmfile.readthedocs.io/en/latest/#installation)**: Declarative spec for deploying helm charts
+- **[kubectl](https://github.com/kubernetes/kubectl)**: Kubernetes' command line tool for communicating with a Kubernetes cluster's control plane, using the Kubernetes API.
+- **[minikube](https://minikube.sigs.k8s.io/docs/start/)**: Local version of Kubernetes to deploy KAI
+- **[pre-commit](https://pre-commit.com/)**: Pre-commit hooks execution tool ensures the best practices are followed before commiting any change
+- **[yq](https://github.com/mikefarah/yq)**: YAML processor. Make sure you have v4+
+
+## Pre-commit hooks setup
+
+From the repository root execute the following commands:
+
+```bash
+pre-commit install
+pre-commit install-hooks
+pre-commit install --hook-type commit-msg
+```
+
+**Note**: _Contributing commits that had not passed the required hooks will be rejected._
+
+## Local Environment
+
+### Requirements
+
+- `GITLAB_TOKEN` variable exported into your shell. See [Personal access
+  tokens](https://docs.gitlab.com/security/tokens/#personal-access-tokens).
+- [Minikube](https://minikube.sigs.k8s.io/docs/start/) >= 1.34
+- [Docker](https://docs.docker.com/get-docker/)
+
+  - [Linux](https://docs.docker.com/desktop/setup/install/linux/) >= 26.1
+  - [Mac](https://docs.docker.com/desktop/setup/install/mac-install/)
+
+  > **NOTE**: _You can use a different driver updating `.kdlctl.conf`; Check [this](https://minikube.sigs.k8s.io/docs/drivers/) for a complete list of drivers for Minikube_
+
+## Basic usage
 
 This repo contains a tool called `./kdlctl.sh` to handle common actions you need during development.
 
@@ -59,7 +99,7 @@ In order to access the admin app, the login process can be done automatically us
 
 You will see an output like this:
 
-```text
+```console
 Login link  : https://kdlapp.kdl.192.168.64.2.nip.io
 👤 User     : kdladmin
 🔑 Password : a123456

--- a/hack/kdlctl.sh
+++ b/hack/kdlctl.sh
@@ -36,6 +36,7 @@ OS=$(uname)
 . ./scripts/kdlctl/cmd_uninstall.sh
 
 check_requirements
+check_required_env_vars
 
 echo
 

--- a/hack/scripts/helmfile/helmfile.yaml
+++ b/hack/scripts/helmfile/helmfile.yaml
@@ -8,9 +8,7 @@ environments:
       - mongodb_password: "123456"
       - mongodb_user: "kdl"
       - mongodb_version: "7.0.15"
-
 ---
-
 helmDefaults:
   createNamespace: true
   atomic: false
@@ -40,6 +38,10 @@ repositories:
     url: https://mongodb.github.io/helm-charts
   - name: reflector
     url: https://emberstack.github.io/helm-charts
+  - name: konstellation-io
+    url: registry.gitlab.intelygenz.com
+    oci: true
+    password: { { requiredEnv "GITLAB_TOKEN" } }
 
 releases:
   # ref: https://github.com/cert-manager/cert-manager/blob/v1.17.1/deploy/charts/cert-manager/values.yaml
@@ -104,7 +106,7 @@ releases:
 
   # ref: https://gitlab.intelygenz.com/konstellation-io/helm-charts/blob/kdl-server-6.2.9/charts/kdl-server/values.yaml
   - name: kdl-local
-    chart: oci://ghcr.io/konstellation-io/helm-charts/kdl-server
+    chart: oci://registry.gitlab.intelygenz.com/konstellation-io/helm-charts/kdl-server
     version: 6.2.9
     namespace: kdl
     needs:

--- a/hack/scripts/helmfile/helmfile.yaml
+++ b/hack/scripts/helmfile/helmfile.yaml
@@ -36,7 +36,7 @@ repositories:
     url: https://charts.min.io/
   - name: mongodb
     url: https://mongodb.github.io/helm-charts
-  - name: reflector
+  - name: emberstack
     url: https://emberstack.github.io/helm-charts
   - name: konstellation-io
     url: registry.gitlab.intelygenz.com

--- a/hack/scripts/helmfile/helmfile.yaml
+++ b/hack/scripts/helmfile/helmfile.yaml
@@ -41,7 +41,7 @@ repositories:
   - name: konstellation-io
     url: registry.gitlab.intelygenz.com
     oci: true
-    password: { { requiredEnv "GITLAB_TOKEN" } }
+    password: {{ requiredEnv "GITLAB_TOKEN" }}
 
 releases:
   # ref: https://github.com/cert-manager/cert-manager/blob/v1.17.1/deploy/charts/cert-manager/values.yaml

--- a/hack/scripts/kdlctl/cmd_minikube.sh
+++ b/hack/scripts/kdlctl/cmd_minikube.sh
@@ -29,6 +29,7 @@ minikube_start() {
     minikube start -p "${MINIKUBE_PROFILE}"
     ;;
   *)
+    export KUBECONFIG="${HOME}/.kube/config-${MINIKUBE_PROFILE}"
     echo_wait "Creating new minikube profile"
     minikube start -p "${MINIKUBE_PROFILE}" \
       --namespace="${NAMESPACE}" \
@@ -52,9 +53,10 @@ minikube_start() {
 }
 
 minikube_profile_update() {
-  export KUBECONFIG=${HOME}/.kube/config-minikube
+  export KUBECONFIG="${HOME}/.kube/config-${MINIKUBE_PROFILE}"
   chmod 600 ${KUBECONFIG}
-  minikube profile "${MINIKUBE_PROFILE}" && minikube update-context
+  minikube profile "${MINIKUBE_PROFILE}"
+  minikube update-context -p "${MINIKUBE_PROFILE}"
 }
 
 minikube_wait_for_registry() {

--- a/hack/scripts/kdlctl/common_functions.sh
+++ b/hack/scripts/kdlctl/common_functions.sh
@@ -40,6 +40,10 @@ check_requirements() {
   fi
 }
 
+check_required_env_vars() {
+  [ -n "${GITLAB_TOKEN+x}" ] || echo_fatal "GITLAB_TOKEN environment variable is required"
+}
+
 cmd_installed() {
   if (command -v "$1" >/dev/null 2>&1); then
     echo 1


### PR DESCRIPTION
## Motivation and Context

The Helmfile currently points to helm-charts in GitHub, so it must be updated to use OCI in GitLab. Additionally, the startup script (`kdlctl.sh`) should be modified to check for the presence of `GITLAB_TOKEN`, which is required to access the GitLab Container Registry where the Helm chart is stored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [x] I have updated the documentation accordingly.
- [x] The commit message follows our guidelines: https://github.com/konstellation-io/kdl-server/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] My change requires a change to the documentation (create a new issue if the documentation has not been updated).

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The Helmfile currently points to helm-charts in GitHub: `oci://ghcr.io/konstellation-io/helm-charts/*`

## What is the new behavior?

The Helmfile will point to helm-charts in GitLab: `oci://registry.gitlab.intelygenz.com/konstellation-io/helm-charts/*`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Closes KDL6-336